### PR TITLE
grml zshrc bugfixes

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2280,7 +2280,7 @@ if ! check_com asc &>/dev/null ; then
 fi
 
 # get top 10 shell commands:
-alias top10='print -l ? ${(o)history%% *} | uniq -c | sort -nr | head -n 10'
+alias top10='print -l ${(o)history%% *} | uniq -c | sort -nr | head -n 10'
 
 # truecrypt; use e.g. via 'truec /dev/ice /mnt/ice' or 'truec -i'
 if check_com -c truecrypt ; then


### PR DESCRIPTION
bug:
use any() with any token that looks like an option or is recognised by expr and any will fail.
i.e. 
$ any index
$ any -i
$ any length

not nice if for example you want to see if an indexer daemon is running

the rest just fixes typos, one of which broke the top10 function
