### PR TITLE
Xro/better cl history navigation

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -609,6 +609,10 @@ bindkey "\e[1;5D" backward-word
 bindkey '^[[1;3C' forward-word
 bindkey '^[[1;3D' backward-word
 
+## alt-backspace is default for backwards-delete-word
+## let's also set alt-delete for delete-word
+bindkey "3~" delete-word
+
 bindkey '^xp'   history-beginning-search-backward
 bindkey '^xP'   history-beginning-search-forward
 bindkey "\e[5~" history-beginning-search-backward #PageUp


### PR DESCRIPTION
this one probably needs to be discussed
currently "up/down-line-or-search" is bound to cursor up/down and searches the history for lines starting with the first word currently on the command line

However "history-beginning-search-backward/forward" is much more useful.
It filters and traverses the history for entries matching the command line UP TO the current Cursor Position.

Basically it overs the same functionality with an optionally more finegrained search.
On readline based shells (see /etc/inputrc) this functionality (which is a decade old) is usually bound to PageUp/PageDown and the first patch does the same for zsh/zle

But now that we have such useful a feature bound to PageUp/PageDown, we could do even more useful stuff with the Cursor Keys by resetting their keybindig to default (up/down-line-or-history)

This way, after finding a history entry with PageUp/Down and accepting the entry by moving the Cursor, we can then go to entries in the history before or after the entry we just found !!

e.g.
HISTORY:
1: cd /abcd/defgh/
2: git rm *(.c-3)
3: git commit && git push

I want the useful commando #2, but only remember that i used it before commiting to git, so i type:

> git commit[PAGEUP][RIGHT][UP]

Next Question: How to make use of Pos1/End keys ?
Answer: by having them move within the command line and the history at the same time:
first press of HOME/END, moves to beginning/end of line (on multiline)
next press to beginning/end of buffer if not already there
and the press after that to beginning/end of the history (on at most the third keypress)

What else is in need of improvement ?
zsh per default binds Alt-Backspace to kill the word left of the cursor.
there is however no keybinding to move between words or kill the word right of the cursor.
This is fixed by binding Alt-Cursor Ctrl-Cursor and Alt-Delete
