### PR TITLE
Xro/purge

### DIFF
--- a/doc/grmlzshrc.t2t
+++ b/doc/grmlzshrc.t2t
@@ -794,6 +794,7 @@ In detail it purges
  - precompiled python code ("*.pyc", "*.pyo") as long as matching "*.py" source is also present
  - LaTeX temp files i.e. "*.(log|toc|aux|nav|snm|out|tex.backup|bbl|blg|bib.backup|vrb|lof|lot|hd|idx)" for any present "*.tex"
  - ghc temp files, as long as matching "*.hs" or "*.lhs" is also present
+ - "*.mood(D)" Files which are missing their corresponding audio file
 
 : **readme()**
 Opens all README-like files in current working directory with the program

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3561,12 +3561,13 @@ purge() {
     TEXTEMPFILES=(*.tex(N:s/%tex/'(log|toc|aux|nav|snm|out|tex.backup|bbl|blg|bib.backup|vrb|lof|lot|hd|idx)(N)'/))
     GHCTEMPFILES=(*.(hs|lhs)(N:r:s/%/'.(hi|hc|(p|u|s)_(o|hi))(N)'/))
     PYTEMPFILES=(*.py(N:s/%py/'(pyc|pyo)(N)'/))
-    FILES=(*~(N) .*~(N) \#*\#(N) *.o(N) a.out(N) (*.|)core(N) *.cmo(N) *.cmi(N) .*.swp(N) *.(orig|rej)(DN) *.dpkg-(old|dist|new)(DN) ._(cfg|mrg)[0-9][0-9][0-9][0-9]_*(N) ${~TEXTEMPFILES} ${~GHCTEMPFILES} ${~PYTEMPFILES})
+    LONELY_MOOD_FILES=((*.mood)(NDe:'local -a AF;AF=( ${${REPLY#.}%mood}(mp3|flac|ogg|asf|wmv|aac)(N) ); [[ -z "$AF" ]]':))
+    FILES=(*~(.N) \#*\#(.N) *.o(.N) a.out(.N) (*.|)core(.N) *.cmo(.N) *.cmi(.N) .*.swp(.N) *.(orig|rej)(.DN) *.dpkg-(old|dist|new)(DN) ._(cfg|mrg)[0-9][0-9][0-9][0-9]_*(N) ${~TEXTEMPFILES} ${~GHCTEMPFILES} ${~PYTEMPFILES} ${LONELY_MOOD_FILES})
     local NBFILES=${#FILES}
     local CURDIRSUDO=""
     [[ ! -w ./ ]] && CURDIRSUDO=$SUDO
     if [[ $NBFILES > 0 ]] ; then
-        print $FILES
+        print -l $FILES
         local ans
         echo -n "Remove these files? [y/n] "
         read -q ans


### PR DESCRIPTION
See http://bts.grml.org/grml/issue986
only It's become much better since.

fixes some bug in original function, like deleting directories ending with ~ or not plain deleting ./core files
adds some nifty globbing pattern generation to purge some common temporary or orphaned files.
