### PR TITLE
Xro/screen hardcopy

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1037,6 +1037,8 @@ if check_com -c screen || check_com -c tmux; then
         # fill array with contents from screen hardcopy
         if ((${+TMUX})); then
             #works, but crashes tmux below version 1.4
+            #luckily tmux -V option to ask for version, was also added in 1.4
+            tmux -V &>/dev/null || return
             tmux -q capture-pane \; save-buffer -b 0 $TMPFILE \; delete-buffer -b 0
         else
             screen -X hardcopy $TMPFILE


### PR DESCRIPTION
- added workaround for apparent screen bug which dumps screen in latin1 encoding no matter what encoding is set
- added support for tmux
- added version check for tmux, since taking a screen hardcopy from zsh completion crashed any tmux below version 1.4
