### PR TITLE
zsh: make any case insensitive

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2245,7 +2245,7 @@ any() {
         echo "any - grep for process(es) by keyword" >&2
         echo "Usage: any <keyword>" >&2 ; return 1
     else
-        ps xauwww | grep --color=auto "[${1[1]}]${1[2,-1]}"
+        ps xauwww | grep -i --color=auto "[${1[1]}]${1[2,-1]}"
     fi
 }
 


### PR DESCRIPTION
just noticed. on OS-X processes tend to start with an Uppercase letter. And sometimes they mix captialization even with multiple processes of the same application. 
So i propose to make the any function work case-insensitive
