### PR TITLE
zsh: fix readme, add liesmich, improve globbing

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3295,8 +3295,10 @@ vman() {
 #f5# View all README-like files in current directory in pager
 readme() {
     emulate -L zsh
+    setopt extendedglob
     local files
     files=(./(#i)*(read*me|lue*m(in|)ut)*(ND))
+    files=(./(#i)*(read*me|lue*m(in|)ut|lies*mich)*(NDr^/=p%))
     if (($#files)) ; then
         $PAGER $files
     else


### PR DESCRIPTION
readme() function is broken, because globbing expression in function requires extendedglob to be set, but "emulate -L zsh" resets zsh options to default (unsetting extendedglob)

also added support for "lies*mich" files and excluded directories, block files, etc from match
