### PR TITLE
zsh: fix smart cd for cd with 2 args

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2786,7 +2786,9 @@ fir() {
 }
 # smart cd function, allows switching to /etc when running 'cd /etc/fstab'
 cd() {
-    if [[ -f ${1} ]]; then
+    if [[ -n ${2} ]]; then
+        builtin cd $@
+    elif [[ -f ${1} ]]; then
         [[ ! -e ${1:h} ]] && return 1
         print "Correcting ${1} to ${1:h}"
         builtin cd ${1:h}


### PR DESCRIPTION
see above, smart cd breaks the zsh feature of cd substring replacement

the feature works like this

```
cdt
mkdir -p a/b/c d/b/c
cd a/b/c
echo we are in a/b/c
cd a d
echo we are in d/b/c
```
