### PR TITLE
Fix: trying to overwrite '/etc/vim/vimrc', which is also in package vim-common 2:7.3.547-7

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Bugs: mailto:bugs@grml.org
 Package: grml-etc-core
 Architecture: all
 Conflicts: grml-etc (<< 0.8-11), grml-autoconfig (<< 0.5-7), grml-scripts (<< 0.8-27)
+Replaces: vim-common
 Depends: vim | nvi | editor
 Recommends: grml-scripts-core
 Pre-Depends: zsh


### PR DESCRIPTION
This is a Replaces without Conflicts+Provides, which tells dpkg to
just go on and overwrite the file and that yes, this is no accident.

(That being said, replacing conffiles is tricky.)

Nevertheless, this makes grml-etc-core installable on wheezy.
