### PR TITLE
zshrc: new abbreviation expansion

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1007,6 +1007,7 @@ abk=(
     'LL'   '|& less -r'
     'M'    '| most'
     'N'    '&>/dev/null'           #d (No Output)
+    'NE'   '|& grep '${grep_options:+"${grep_options[*]}"}' -vE "^\s*(#|$)"' #d (Silence comments and empty lines)
     'R'    '| tr A-z N-za-m'       #d (ROT13)
     'SL'   '| sort | less'
     'S'    '| sort -u'


### PR DESCRIPTION
NE expands to a grep expression that filters empty lines and lines starting with a # (stands for Not Empty)
Useful when cat-ing conf files (among others)