### PR TITLE
Avoid placing empty components in PATH; reorder root's PATH

### DIFF
--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -85,19 +85,20 @@ if (( EUID != 0 )); then
     /sbin
     /usr/local/games
     /usr/games
-    "${ADDONS}"
-    "${path[@]}"
+    ${ADDONS}
+    ${path[@]}
   )
 else
   path=(
+    $HOME/bin
+    /usr/local/sbin
+    /usr/local/bin
     /sbin
     /bin
     /usr/sbin
     /usr/bin
-    /usr/local/sbin
-    /usr/local/bin
-    "${ADDONS}"
-    "${path[@]}"
+    ${ADDONS}
+    ${path[@]}
   )
 fi
 


### PR DESCRIPTION
zsh treats an empty PATH component ("::") as ".", which creates a security hole.

Removing the unnecessary quotes around "$ADDONS" and "$path[@]" avoids putting an empty array element into the path array. The substitutions are still whitespace safe because zsh doesn't split words unless told to do so explicitly.

As agreed on #grml, root's PATH should also list /usr/local/sbin and bin before /sbin, /bin, /usr/sbin and /usr/bin; and there is no harm in adding $HOME/bin unconditionally as the first PATH component.