### PR TITLE
Akorn path sanitization 1

### DIFF
--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -85,19 +85,20 @@ if (( EUID != 0 )); then
     /sbin
     /usr/local/games
     /usr/games
-    "${ADDONS}"
-    "${path[@]}"
+    ${ADDONS}
+    ${path[@]}
   )
 else
   path=(
+    $HOME/bin
+    /usr/local/sbin
+    /usr/local/bin
     /sbin
     /bin
     /usr/sbin
     /usr/bin
-    /usr/local/sbin
-    /usr/local/bin
-    "${ADDONS}"
-    "${path[@]}"
+    ${ADDONS}
+    ${path[@]}
   )
 fi
 

--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -85,8 +85,8 @@ if (( EUID != 0 )); then
     /sbin
     /usr/local/games
     /usr/games
-    ${ADDONS}
-    ${path[@]}
+    "${ADDONS}"
+    "${path[@]}"
   )
 else
   path=(
@@ -97,10 +97,12 @@ else
     /bin
     /usr/sbin
     /usr/bin
-    ${ADDONS}
-    ${path[@]}
+    "${ADDONS}"
+    "${path[@]}"
   )
 fi
+
+path=( "${path[@]:#}" )
 
 typeset -U path
 


### PR DESCRIPTION
In #48 @ft suggested that the quotes in the expansions of `ADDONS` and `path` be re-added and that `path` be sanitized using a substitution that drops empty components.

This newer patch does it that way.