### PR TITLE
zshrc: fix screen alias

### DIFF
--- a/doc/grmlzshrc.t2t
+++ b/doc/grmlzshrc.t2t
@@ -1020,11 +1020,11 @@ Executes the commands on the versioned patch queue from current repository.
 : **rmcdir** (//'cd ..; rmdir $OLDPWD || cd $OLDPWD//)
 rmdir current working directory
 
-: **screen** (///usr/bin/screen -c ${HOME}/.screenrc//)
+: **screen** (//screen -c file//)
 If invoking user is root, starts screen session with /etc/grml/screenrc
-as config file. If invoked by a regular user, start a screen session
-with users .screenrc config if it exists, else use /etc/grml/screenrc_grml
-as configuration.
+as config file. If invoked by a regular user and users .screenc does not exist,
+starts screen with /etc/grml/screenrc_grml config if it exists, else fallbacks
+to /etc/grml/screenrc.
 
 : **su** (//sudo su//)
 If user is running a Grml live system, don't ask for any password, if she

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2504,16 +2504,14 @@ hash -d www=/var/www
 if check_com -c screen ; then
     if [[ $UID -eq 0 ]] ; then
         if [[ -r /etc/grml/screenrc ]]; then
-            alias screen="${commands[screen]} -c /etc/grml/screenrc"
+            alias screen='screen -c /etc/grml/screenrc'
         fi
-    elif [[ -r $HOME/.screenrc ]] ; then
-        alias screen="${commands[screen]} -c $HOME/.screenrc"
-    else
+    elif [[ ! -r $HOME/.screenrc ]] ; then
         if [[ -r /etc/grml/screenrc_grml ]]; then
-            alias screen="${commands[screen]} -c /etc/grml/screenrc_grml"
+            alias screen='screen -c /etc/grml/screenrc_grml'
         else
             if [[ -r /etc/grml/screenrc ]]; then
-                alias screen="${commands[screen]} -c /etc/grml/screenrc"
+                alias screen='screen -c /etc/grml/screenrc'
             fi
         fi
     fi


### PR DESCRIPTION
- Using `${commands[screen]}` which is expanded in double quotes makes it impossible to use custom screen installation or wrapper.  Use `screen` instead.
- Screen reads configuration from `$HOME/.screenrc` by default so it is redundant to set alias for this.