### PR TITLE
tmux: remove obsolete mouse-select-pane option

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -41,7 +41,6 @@ bind-key - command-prompt -p "exec:" "split-window -v '%%'"
 set -s escape-time 0
 set -g default-terminal "screen-256color"
 set -g display-panes-time 3000
-set -g mouse-select-pane off
 set -g visual-activity on
 set -g mode-keys vi
 


### PR DESCRIPTION
This pull request removes the obsolete `mouse-select-pane` option from the tmux config.

Since the `mouse-select-pane` is deactivated in the config anyway and is off by default, this does not affect the current behaviour in any way. It does, however, fix the `unknown option: mouse-select-pane` warnings produced by tmux 2.1.