### PR TITLE
Lookup: Fix warn_create_global warnings

### DIFF
--- a/usr_share_grml/zsh/functions/Lookup/LOOKUP_parseopts
+++ b/usr_share_grml/zsh/functions/Lookup/LOOKUP_parseopts
@@ -81,6 +81,7 @@ if [[ $1 == -* ]] && [[ $1 != ${firstarg} ]] ; then
     return 1
 fi
 for o in ${(k)opts} ; do
+    local mbegin mend
     match=()
     : ${o/(#b)-(*)/}
     char="${match[1]}"


### PR DESCRIPTION
This fixes warnings that occur whenever opening a login shell on Debian Stretch.