### PR TITLE
zshrc: dirstack: skip for ZSH_SUBSHELL

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1613,6 +1613,7 @@ if zstyle -T ':grml:chpwd:dirstack' enable; then
     }
 
     chpwd() {
+        (( ZSH_SUBSHELL )) && return
         (( $DIRSTACKSIZE <= 0 )) && return
         [[ -z $DIRSTACKFILE ]] && return
         grml_dirstack_filter $PWD && return


### PR DESCRIPTION
Otherwise `(cd foo)` would add `foo` to the stack, which is probably not
what you would expect.

Side note: the hook should be installed through `add-zsh-hook` probably?!

I am not using grml myself, but had taken this part a while ago.