### PR TITLE
etc/zsh/zshrc: date invocation in bk() now uses local timezone instead of UTC

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3203,7 +3203,7 @@ fi
 #f5# Backup \kbd{file_or_folder {\rm to} file_or_folder\_timestamp}
 bk() {
     emulate -L zsh
-    local current_date=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
+    local current_date=$(date +"%Y-%m-%dT%H:%M:%S%z")
     local clean keep move verbose result all to_bk
     setopt extended_glob
     keep=1


### PR DESCRIPTION
This change works across all my OSes (GNU/Linux, FreeBSD and OpenBSD) and should even be POSIX.