### PR TITLE
bk(): Remove the separators between the units of time

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3268,7 +3268,7 @@ fi
 #f5# Backup \kbd{file_or_folder {\rm to} file_or_folder\_timestamp}
 function bk () {
     emulate -L zsh
-    local current_date=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
+    local current_date=$(date -u "+%Y%m%dT%H%M%SZ")
     local clean keep move verbose result all to_bk
     setopt extended_glob
     keep=1
@@ -3325,14 +3325,14 @@ return 0;;
     elif (( clean > 0 )); then
         if (( $# > 0 )); then
             for to_bk in "$@"; do
-                rm $verbose -rf "${to_bk%/}"_[0-9](#c4,)-(0[0-9]|1[0-2])-([0-2][0-9]|3[0-1])T([0-1][0-9]|2[0-3])(:[0-5][0-9])(#c2)Z
+                rm $verbose -rf "${to_bk%/}"_[0-9](#c8)T([0-1][0-9]|2[0-3])([0-5][0-9])(#c2)Z
                 (( result += $? ))
             done
         else
             if (( all > 0 )); then
-                rm $verbose -rf *_[0-9](#c4,)-(0[0-9]|1[0-2])-([0-2][0-9]|3[0-1])T([0-1][0-9]|2[0-3])(:[0-5][0-9])(#c2)Z(D)
+                rm $verbose -rf *_[0-9](#c8)T([0-1][0-9]|2[0-3])([0-5][0-9])(#c2)Z(D)
             else
-                rm $verbose -rf *_[0-9](#c4,)-(0[0-9]|1[0-2])-([0-2][0-9]|3[0-1])T([0-1][0-9]|2[0-3])(:[0-5][0-9])(#c2)Z
+                rm $verbose -rf *_[0-9](#c8)T([0-1][0-9]|2[0-3])([0-5][0-9])(#c2)Z
             fi
             (( result += $? ))
         fi


### PR DESCRIPTION
In PR #60 we discussed the use of the local timezone instead of UTC.
While doing so we figured out that the current implementation is broken
on VFAT.

This solution removes the delimiters between the units of time which is fully
IS0 8601 compliant and should work well on all filesystems.

@moviuro: I did not want to interfere with your PR, so I would be pleased if you can give me any feedback to this change. (Using the local time vs UTC should be discussed in your PR, but removing the separators is needed anyway).

/cc @mika, @btittelbach (please take a look if you have some time).

NOTE: this PR had to be recreated as the one PR #68 was closed automatically because I pushed to grml/grml-etc-core instead into my fork (jkirk/grml-etc-core).