### PR TITLE
Disable bracketed paste mode for dumb terminals

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3733,6 +3733,9 @@ if check_com -c hg ; then
 
 fi # end of check whether we have the 'hg'-executable
 
+# disable bracketed paste mode for dumb terminals
+[[ "$TERM" == dumb ]] && unset zle_bracketed_paste
+
 # grml-small cleanups and workarounds
 
 # The following is used to remove zsh-config-items that do not work


### PR DESCRIPTION
Starting with zsh version 5.1, ZLE began supporting "bracketed paste mode".

Currently, even on dumb terminals, ZLE sometimes emits the escape sequence "[?2004h" after the prompt if bracketed paste mode is not disabled. This prevents various tools that try to detect a shell prompt (such as Emacs TRAMP) from doing so successfully. (The shell prompt effectively becomes `user@host ~ % [?2004h` – which typically will not be matched by prompt detecting regexps, thereby breaking Emacs TRAMP for target hosts that use the Grml zsh config and zsh ≥5.1.)

Since most "dumb" terminals do not have bracketed paste capabilities anyway, this pull request changes the Grml zsh config to disable bracketed paste mode for "dumb" terminals.