### PR TITLE
tmux: use foo-style to set status styles

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -45,8 +45,7 @@ set -g visual-activity on
 set -g mode-keys vi
 
 ### set status line appearance
-set -g status-fg white
-set -g status-bg black
+set -g status-style fg=white,bg=black
 
 set -g status-left-length 28
 ### status-left:  @hostname:sessionname
@@ -61,7 +60,5 @@ set -g status-right '#[fg=yellow]%Y-%m-%d %H:%M'
 #set -g status-right-length 6
 #set -g status-right "#[fg=yellow]%H:%M"
 
-set-window-option -g window-status-fg blue
-set-window-option -g window-status-bg black
-set-window-option -g window-status-current-attr bold
-
+set-window-option -g window-status-style fg=blue,bg=black
+set-window-option -g window-status-current-style bold


### PR DESCRIPTION
From tmux 1.9, (20 Feb 2014), foo-{bg,fg,attr} commands have been
deprecated and tmux recommended to use foo-style instead.

Those options have been removed from tmux 2.9

It's more than 5 years from the deprecation of foo-{bg,fg,attr}.
it should be safe to use the new option by now.

Signed-off-by: Doan Tran Cong Danh <congdanhqx@gmail.com>