### PR TITLE
Update style options to be tmux 2.9 comptible

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -45,8 +45,7 @@ set -g visual-activity on
 set -g mode-keys vi
 
 ### set status line appearance
-set -g status-fg white
-set -g status-bg black
+set -g status-style bg=black,fg=white
 
 set -g status-left-length 28
 ### status-left:  @hostname:sessionname
@@ -61,7 +60,5 @@ set -g status-right '#[fg=yellow]%Y-%m-%d %H:%M'
 #set -g status-right-length 6
 #set -g status-right "#[fg=yellow]%H:%M"
 
-set-window-option -g window-status-fg blue
-set-window-option -g window-status-bg black
-set-window-option -g window-status-current-attr bold
-
+set -g window-status-style bg=black,fg=blue
+set -g window-status-current-style bold


### PR DESCRIPTION
Per https://github.com/tmux/tmux/wiki/FAQ#how-do-i-translate--fg--bg-and--attr-options-into--style-options
> In tmux 1.9 each set of three options were combined into a single option (so mode-fg, mode-bg and mode-attr became mode-style) and in tmux 2.9 the old options were removed.

From https://github.com/tmux/tmux/issues/1689#issuecomment-486722349
> The form is exactly the same, it is just one option instead of three:
> 
> `set -g mode-style bg=red,fg=green,blink`

Tested on tmux 2.9a (OSX)