### PR TITLE
Update obsolete window-status config options

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -61,7 +61,5 @@ set -g status-right '#[fg=yellow]%Y-%m-%d %H:%M'
 #set -g status-right-length 6
 #set -g status-right "#[fg=yellow]%H:%M"
 
-set-window-option -g window-status-fg blue
-set-window-option -g window-status-bg black
-set-window-option -g window-status-current-attr bold
-
+set-window-option -g window-status-style fg=blue,bg=black
+set-window-option -g window-status-current-style bold


### PR DESCRIPTION
Before tmux 1.9 styles were configured using three options per style:

- a foreground option (e.g. foobar-fg)
- a background option (e.g. foobar-bg)
- an attribute option (e.g. foobar-attr)

In tmux 1.9, these options were merged into a single style option
(e.g. foobar-style) and in in tmux 2.9, support for the aforementioned
deprecated style options (foobar-fg, foobar-bg, foobar-attr) was
dropped.

This commit changes the window-status and window-status-current style
optiosn to use the new style format.