### PR TITLE
zshrc: Reset $REPLY parameter before calling prompt token functions

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2269,6 +2269,7 @@ grml_theme_add_token: Token `%s'\'' exists! Giving up!\n\n' $name
         return 2
     fi
     if (( init )); then
+        REPLY=''
         $token $name
         token=$REPLY
     fi
@@ -2314,6 +2315,7 @@ function grml_prompt_addto () {
         zstyle -s ":prompt:${grmltheme}:${lr}:items:$it" token new \
             || new=${grml_prompt_token_default[$it]}
         if (( ${+grml_prompt_token_function[$it]} )); then
+            REPLY=''
             ${grml_prompt_token_function[$it]} $it
         else
             case $it in


### PR DESCRIPTION
It may be tempting to write a prompt token function like this

    if (( ${+commands[kerl]} )) REPLY=$(kerl prompt '<%s> ')

But if the command does not exist user may be end up with duplicated
tokens in her prompt.  Resetting `$REPLY` parameter before calling
user-defined functions prevents this problem.