### PR TITLE
screenrc: Add 'xterm-256color' to terminals

### DIFF
--- a/etc/grml/screenrc_generic
+++ b/etc/grml/screenrc_generic
@@ -140,7 +140,7 @@
 # To get screen to add lines to xterm's scrollback buffer, uncomment the
 # following termcapinfo line which tells xterm to use the normal screen buffer
 # (which has scrollback), not the alternate screen buffer.
-  termcapinfo xterm|xterms|xs|rxvt ti@:te@
+  termcapinfo xterm|xterm-256color|xterms|xs|rxvt ti@:te@
 
 # Welcome the user:
   echo "welcome BoFH!"


### PR DESCRIPTION
KDE's Konsole terminal sets env variable TERM to 'xterm-256color' by
default in newer versions, so the scrollbar fix did not match anymore.

---

This actually annoyed me for a long time now, and today I decided to do my research. I found the original solution at http://www4.cs.fau.de/~jnweiger/screen-faq.html and then realized it was all right there in grml's screenrc, only missing the little piece from this commit.