### PR TITLE
zsh: commit-to-history: keep escaped character

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -895,7 +895,7 @@ zle -N end-of-somewhere beginning-or-end-of-somewhere
 
 # add a command line to the shells history without executing it
 function commit-to-history () {
-    print -s ${(z)BUFFER}
+    print -rs ${(z)BUFFER}
     zle send-break
 }
 zle -N commit-to-history


### PR DESCRIPTION
Prior to this change, when committing this line to history

    echo "hello\"world"

zsh will record this line in history instead:

    echo "hello"world"

because the \" is processed by print.

Correct it by print in raw mode.

Signed-off-by: Doan Tran Cong Danh <congdanhqx@gmail.com>