### PR TITLE
tmux.conf: Fix unknown key: confirm-before error message

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -16,7 +16,7 @@ unbind space
 bind-key space next-window
 bind-key C-space next-window
 bind-key K confirm-before kill-pane
-bind-key \ confirm-before kill-session
+bind-key \\ confirm-before kill-session
 #bind-key C-h previous-window
 
 ### join the last active pane to the currently active window


### PR DESCRIPTION
Quoting the man page tmux(1) of v3.1b:

| Any other characters preceded by \ are replaced by themselves (that is,
| the \ is removed) and are not treated as having any special meaning - so
| for example \; will not mark a command sequence and \$ will not expand
| an environment variable.

and quoting the man page tmux(1) of v2.8:

| Each command should be separated by spaces and a semicolon; commands are
| executed sequentially from left to right and lines ending with a
| backslash continue on to the next line, except when escaped by another
| backslash.  A literal semicolon may be included by escaping it with a
| backslash (for example, when specifying a command sequence to bind-key).

This implies that a backslash should also be escaped by a backslash but
tmux still used to work with the unescaped backslash in older versions.

This change has been tested with the tmux versions running
Debian/jessie, Debian/stretch, Debian/buster and Debian/bullseye
(currently testing):

* Debian/jessie: v1.9
* Debian/stretch: v2.3
* Debian/buster: v2.8
* Debian/bullseye: v3.1

Closes: grml/grml-etc-core#93