### PR TITLE
zshrc:  Fix darwin battery info field selection

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1856,7 +1856,7 @@ done
 function batterydarwin () {
 GRML_BATTERY_LEVEL=''
 local -a table
-table=( ${$(pmset -g ps)[(w)7,8]%%(\%|);} )
+table=( ${$(pmset -g ps)[(w)8,9]%%(\%|);} )
 if [[ -n $table[2] ]] ; then
     case $table[2] in
         charging)


### PR DESCRIPTION
The batterydarwin function looks for the info it wants using field
numbers that are off by one on the current version of Mac OS.  I'm not
sure which version this changed in or what exactly they added (I suspect
it is the battery ID), but this patch makes battery info start working
again.