### PR TITLE
zshsrc: support hostnamectl iff hostname isn't present

### DIFF
--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -26,7 +26,13 @@
 [[ -r /etc/environment ]] && source /etc/environment
 
 # set environment variables (important for autologin on tty)
-export HOSTNAME=${HOSTNAME:-$(hostname)}
+if [ -n "${HOSTNAME}" ] ; then
+  export HOSTNAME="${HOSTNAME}"
+elif [[ -x $(which hostname) ]] ; then
+  export HOSTNAME="$(hostname)"
+elif [[ -x $(which hostnamectl) ]] ; then
+  export HOSTNAME="$(hostnamectl --static)"
+fi
 
 # make sure /usr/bin/id is available
 if [[ -x /usr/bin/id ]] ; then

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -837,8 +837,16 @@ function grmlcomp () {
         _ssh_hosts=()
         _etc_hosts=()
     fi
+
+    local localname
+    if check_com hostname ; then
+      localname=$(hostname)
+    elif check_com hostnamectl ; then
+      localname=$(hostnamectl --static)
+    fi
+
     hosts=(
-        $(hostname)
+        "${localname}"
         "$_ssh_config_hosts[@]"
         "$_ssh_hosts[@]"
         "$_etc_hosts[@]"
@@ -2509,8 +2517,15 @@ function grml_vcs_to_screen_title () {
 }
 
 function grml_maintain_name () {
-    # set hostname if not running on host with name 'grml'
-    if [[ -n "$HOSTNAME" ]] && [[ "$HOSTNAME" != $(hostname) ]] ; then
+    local localname
+    if check_com hostname ; then
+      localname=$(hostname)
+    elif check_com hostnamectl ; then
+      localname=$(hostnamectl --static)
+    fi
+
+    # set hostname if not running on local machine
+    if [[ -n "$HOSTNAME" ]] && [[ "$HOSTNAME" != "${localname}" ]] ; then
        NAME="@$HOSTNAME"
     fi
 }


### PR DESCRIPTION
The hostname binary doesn't necessarily exist, while
hostnamectl is available.

Closes: grml/grml-etc-core#96