### PR TITLE
tmux.conf: Fix /etc/tmux.conf:19: unknown key: \\ error message

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -16,7 +16,7 @@ unbind space
 bind-key space next-window
 bind-key C-space next-window
 bind-key K confirm-before kill-pane
-bind-key \\ confirm-before kill-session
+bind-key '\' confirm-before kill-session
 #bind-key C-h previous-window
 
 ### join the last active pane to the currently active window


### PR DESCRIPTION
The previous change (see: c2cbdb01) tried to fix the error
  "unknown key:  confirm-before".

Unfortunately that change only solved the problem for tmux v3.0+.
(Starting a new tmux session and reloading the configuration did not
bring up the error message in the older (<v3.0) tmux versions, so I
wrongly assumed that the change also worked for older versions.)

The changelog ("CHANGES FROM 2.9 to 3.0") states the following:

|  INCOMPATIBLE: tmux's configuration parsing has changed to use yacc(1). There
|  is one incompatible change: a \ on its own must be escaped or quoted as
|  either \\ or '\' (the latter works on older tmux versions).

|  Entirely the same parser is now used for parsing the configuration file
|  and for string commands. This means that constructs previously only
|  available in .tmux.conf, such as %if, can now be used in string commands
|  (for example, those given to if-shell - not commands invoked from the
|  shell, they are still parsed by the shell itself).

This change has been tested (I really hope so!) with the tmux versions
running Debian/jessie (docker), Debian/stretch (docker), Debian/buster
(host system) and Debian/bullseye (Grml daily ISO):

* Debian/jessie: v1.9
* Debian/stretch: v2.3
* Debian/buster: v2.8
* Debian/bullseye: v3.1

Closes (again): grml/grml-etc-core#93