### PR TITLE
zshenv, zshrc: add fallback to uname for HOSTNAME

### DIFF
--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -32,6 +32,8 @@ elif [[ -x $(which hostname) ]] ; then
   export HOSTNAME="$(hostname)"
 elif [[ -x $(which hostnamectl) ]] ; then
   export HOSTNAME="$(hostnamectl --static)"
+else
+  export HOSTNAME="$(uname -n)"
 fi
 
 # make sure /usr/bin/id is available

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -843,6 +843,8 @@ function grmlcomp () {
       localname=$(hostname)
     elif check_com hostnamectl ; then
       localname=$(hostnamectl --static)
+    else
+      localname="$(uname -n)"
     fi
 
     hosts=(
@@ -2522,6 +2524,8 @@ function grml_maintain_name () {
       localname=$(hostname)
     elif check_com hostnamectl ; then
       localname=$(hostnamectl --static)
+    else
+      localname="$(uname -n)"
     fi
 
     # set hostname if not running on local machine


### PR DESCRIPTION
`uname -n` is POSIX, and should work when neither hostname(1) nor hostnamectl(1) exist.

Enhances #97, see #96 