### PR TITLE
vimrc: support vim-tiny and older versions of vim

### DIFF
--- a/etc/vim/vimrc
+++ b/etc/vim/vimrc
@@ -27,7 +27,11 @@ runtime! debian.vim
 " | Do *not* source $VIMRUNTIME/defaults.vim (in case no user vimrc is found),
 " | since that prevents overwriting values we want to set in this file,
 " | instead we set settings similar to what can be found in default.vim below
-let g:skip_defaults_vim=1
+" |
+" | Only do this part when Vim was compiled with the +eval feature.
+if 1
+  let g:skip_defaults_vim=1
+endif
 
 " Use Vim settings, rather than Vi settings (much better!).
 " This must be first, because it changes other options as a side effect.
@@ -54,7 +58,10 @@ set ttimeout		" time out for key codes
 set ttimeoutlen=100	" wait up to 100ms after Esc for special key
 
 " Show @@@ in the last line if it is truncated.
-set display=truncate
+" | This features is only available in later versions
+if has("patch-7.4.2115")
+  set display=truncate
+endif
 
 " Show a few lines of context around the cursor.  Note that this makes the
 " text scroll if you mouse-click near the start or end of the window.
@@ -194,7 +201,11 @@ endif
 
 " list of strings used for list mode
 " set list listchars=eol:$
-  set listchars=eol:$,precedes:«,extends:»,tab:»·,trail:·
+  if (&encoding =~ 'utf-8')
+    set listchars=eol:$,precedes:«,extends:»,tab:»·,trail:·
+  else
+    set listchars=eol:$
+  endif
 
 " list of file names to search for tags
 " set tags=./tags,tags


### PR DESCRIPTION
If vim-tiny is present (lacking +eval feature, see `vim --version`),
then invoking vim fails with:

| Error detected while processing /usr/share/vim/vimrc:
| line   30:
| E319: Sorry, the command is not available in this version: let g:skip_defaults_vim=1

The file /usr/share/vim/vimrc is a symlink to /etc/vim/vimrc:

| % ls -la /usr/share/vim/vimrc
| lrwxrwxrwx 1 root root 14 May 12 02:37 /usr/share/vim/vimrc -> /etc/vim/vimrc

So if the eval feature is missing, don't set skip_defaults_vim=1.

Furthermore, on older vim versions we're failing with:

| Error detected while processing /code/etc/vim/vimrc:
| line   61:
| E474: Invalid argument: display=truncate
| line  201:
| E474: Invalid argument: listchars=eol:$,precedes:«,extends:»,tab:»·,trail:·

The "set display=truncate" only works as of patch-7.4.2115 or newer,
see upstream vim.git commit b9a46fec3e79.

The listchars setting only works when running in utf-8 mode,
by default vim-tiny is running in latin1 though.

Closes: grml/grml-etc-core#99