### PR TITLE
zshrc: url-quote-magic depends on bracketed-paste-magic since zsh 5.1

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -113,6 +113,11 @@ fi
 
 # check for version/system
 # check for versions (compatibility reasons)
+function is51 () {
+    [[ $ZSH_VERSION == 5.<1->* ]] && return 0
+    return 1
+}
+
 function is4 () {
     [[ $ZSH_VERSION == <4->* ]] && return 0
     return 1
@@ -1584,7 +1589,13 @@ zrcautoload zed
 # else
 #    print 'Notice: no url-quote-magic available :('
 # fi
-alias url-quote='autoload -U url-quote-magic ; zle -N self-insert url-quote-magic'
+if is51 ; then
+  # url-quote doesn't work without bracketed-paste-magic since Zsh 5.1
+  alias url-quote='autoload -U bracketed-paste-magic url-quote-magic;
+                   zle -N bracketed-paste bracketed-paste-magic; zle -N self-insert url-quote-magic'
+else
+  alias url-quote='autoload -U url-quote-magic ; zle -N self-insert url-quote-magic'
+fi
 
 #m# k ESC-h Call \kbd{run-help} for the 1st word on the command line
 alias run-help >&/dev/null && unalias run-help


### PR DESCRIPTION
url-quote with zsh >=5.1 does no longer work as such, it depends
on bracketed-paste-magic to work as it used to do

See https://github.com/zsh-users/zsh/blob/68405f31a043bdd5bf338eb06688ed3e1f740937/README#L38-L45
and https://archive.zhimingwang.org/blog/2015-09-21-zsh-51-and-bracketed-paste.html#update
and https://github.com/sorin-ionescu/prezto/issues/978

/cc @ft @btittelbach @jkirk I'd appreciate a review whether this makes sense as such, thanks!