### PR TITLE
zshrc: rely only on `uname -n` for $HOSTNAME handling

### DIFF
--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -27,13 +27,9 @@
 
 # set environment variables (important for autologin on tty)
 if [ -n "${HOSTNAME}" ] ; then
-  export HOSTNAME="${HOSTNAME}"
-elif [[ -x $(which hostname) ]] ; then
-  export HOSTNAME="$(hostname)"
-elif [[ -x $(which hostnamectl) ]] ; then
-  export HOSTNAME="$(hostnamectl --static)"
+    export HOSTNAME="${HOSTNAME}"
 else
-  export HOSTNAME="$(uname -n)"
+    export HOSTNAME="$(uname -n)"
 fi
 
 # make sure /usr/bin/id is available

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2520,13 +2520,7 @@ function grml_vcs_to_screen_title () {
 
 function grml_maintain_name () {
     local localname
-    if check_com hostname ; then
-      localname=$(hostname)
-    elif check_com hostnamectl ; then
-      localname=$(hostnamectl --static)
-    else
-      localname="$(uname -n)"
-    fi
+    localname="$(uname -n)"
 
     # set hostname if not running on local machine
     if [[ -n "$HOSTNAME" ]] && [[ "$HOSTNAME" != "${localname}" ]] ; then


### PR DESCRIPTION
There's no need to invoke `hostname` or `hostnamectl --static`
when `uname -n` is POSIX.

Thanks: Darshaka Pathirana and Chris Hofstaedtler
Closes: grml/grml-etc-core#100