### PR TITLE
zshrc: enable transient_rprompt to fix sad-smiley situation in rprompt

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2478,6 +2478,9 @@ else
     function precmd () { (( ${+functions[vcs_info]} )) && vcs_info; }
 fi
 
+# make sure to use right prompt only when not running a command
+is41 && setopt transient_rprompt
+
 # Terminal-title wizardry
 
 function ESC_print () {


### PR DESCRIPTION
This feature got lost in commit 08ab5d9, but nobody really noticed
this until we got annoyed by the sad-smiley on the right sight of the
prompt (rprompt) and wanted to disable the smiley overall. :)

But once the transient_rprompt option is active, the annoying
c/p behavior with the sad-smiley no longer exists, while
the feature is still there.

FTR, the rprompt in the grml prompt can be disabled e.g. with:

  zstyle ':prompt:grml:right:setup' use-rprompt false

Thanks: Frank Terbeck
Closes: grml/grml-etc-core#107