### PR TITLE
zshrc: set title in alacritty

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2505,7 +2505,7 @@ function grml_reset_screen_title () {
     # see http://www.faqs.org/docs/Linux-mini/Xterm-Title.html
     [[ ${NOTITLE:-} -gt 0 ]] && return 0
     case $TERM in
-        (xterm*|rxvt*)
+        (xterm*|rxvt*|alacritty)
             set_title ${(%):-"%n@%m: %~"}
             ;;
     esac
@@ -2542,7 +2542,7 @@ function grml_cmd_to_screen_title () {
 
 function grml_control_xterm_title () {
     case $TERM in
-        (xterm*|rxvt*)
+        (xterm*|rxvt*|alacritty)
             set_title "${(%):-"%n@%m:"}" "$2"
             ;;
     esac


### PR DESCRIPTION
[Alacritty](https://github.com/alacritty/alacritty) is a “cross-platform, GPU-accelerated terminal emulator” written in Rust. By default, its window title is “Alacritty”. Since its `TERM` value is `alacritty`, zsh with the grml zshrc does not set the window title. This PR adds `alacritty` to the supported `TERM`s for setting the window title.