### PR TITLE
zshrc: change sudo-command-line switch 'sudo'

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1201,9 +1201,9 @@ zle -N grml-zsh-fg
 function sudo-command-line () {
     [[ -z $BUFFER ]] && zle up-history
     local cmd="sudo "
-    if [[ ${BUFFER:0:${#cmd}} == ${cmd} ]]; then
+    if [[ ${BUFFER} == ${cmd}* ]]; then
         CURSOR=$(( CURSOR-${#cmd} ))
-        BUFFER="${BUFFER:${#cmd}}"
+        BUFFER="${BUFFER#$cmd}"
     else
         BUFFER="${cmd}${BUFFER}"
         CURSOR=$(( CURSOR+${#cmd} ))

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1200,10 +1200,15 @@ zle -N grml-zsh-fg
 # run command line as user root via sudo:
 function sudo-command-line () {
     [[ -z $BUFFER ]] && zle up-history
-    if [[ $BUFFER != sudo\ * ]]; then
-        BUFFER="sudo $BUFFER"
-        CURSOR=$(( CURSOR+5 ))
+    local cmd="sudo "
+    if [[ ${BUFFER:0:${#cmd}} == ${cmd} ]]; then
+        CURSOR=$(( CURSOR-${#cmd} ))
+        BUFFER="${BUFFER:${#cmd}}"
+    else
+        BUFFER="${cmd}${BUFFER}"
+        CURSOR=$(( CURSOR+${#cmd} ))
     fi
+    zle reset-prompt
 }
 zle -N sudo-command-line
 


### PR DESCRIPTION
fix add 'sudo' plugin zsh-syntax-highlighting error

If not `sudo`, use `sudo-command-line` add

```sh
ls

# sudo-command-line

sudo ls
```

If has `sudo`, use `sudo-command-line` remove

```
sudo ls

# sudo-command-line

ls 
```


If use zsh plugin `zsh-syntax-highlighting`, run `sudo-command-line` this color error. need `reset-prompt`

