### PR TITLE
remove dependency of hostname[ctl]

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -901,14 +901,7 @@ function grmlcomp () {
     fi
 
     local localname
-    if check_com hostname ; then
-      localname=$(hostname)
-    elif check_com hostnamectl ; then
-      localname=$(hostnamectl --static)
-    else
-      localname="$(uname -n)"
-    fi
-
+    localname="$(uname -n)"
     hosts=(
         "${localname}"
         "$_ssh_config_hosts[@]"


### PR DESCRIPTION
Futher improve #105 . There is another place using hostname[ctl].