### PR TITLE
zshrc: discard stderr from vcs_info

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2411,7 +2411,7 @@ function grml_prompt_addto () {
             vcs)
                 v="vcs_info_msg_${new}_"
                 if (( ! vcscalled )); then
-                    vcs_info
+                    vcs_info 2>/dev/null
                     vcscalled=1
                 fi
                 if (( ${+parameters[$v]} )) && [[ -n "${(P)v}" ]]; then


### PR DESCRIPTION
Changing directory to a bare git repository results in error messages
being printed:

fatal: this operation must be run in a work tree

This is really annoying, especially when working with git - you do not
know if your command complained or zsh prompt generated it.

So let's just discard stderr from vcs_info.