### PR TITLE
Ignore hosts set to invalid/loopback addresses for $_etc_hosts 

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -894,7 +894,7 @@ function grmlcomp () {
     if is42 ; then
         [[ -r ~/.ssh/config ]] && _ssh_config_hosts=(${${(s: :)${(ps:\t:)${${(@M)${(f)"$(<$HOME/.ssh/config)"}:#Host *}#Host }}}:#*[*?]*}) || _ssh_config_hosts=()
         [[ -r ~/.ssh/known_hosts ]] && _ssh_hosts=(${${${${(f)"$(<$HOME/.ssh/known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _ssh_hosts=()
-        [[ -r /etc/hosts ]] && [[ "$NOETCHOSTS" -eq 0 ]] && : ${(A)_etc_hosts:=${(s: :)${(ps:\t:)${${(f)~~"$(</etc/hosts)"}%%\#*}##[:blank:]#[^[:blank:]]#}}} || _etc_hosts=()
+        [[ -r /etc/hosts ]] && [[ "$NOETCHOSTS" -eq 0 ]] && : ${(A)_etc_hosts:=${(s: :)${(ps:\t:)${${(f)~~"$(grep -v '^0\.0\.0.\0\|^127\.0\.0\.1\|^::1 ' /etc/hosts)"}%%\#*}##[:blank:]#[^[:blank:]]#}}} || _etc_hosts=()
     else
         _ssh_config_hosts=()
         _ssh_hosts=()


### PR DESCRIPTION
This significantly improves the loading times of the grml zshrc file in
the case a user decides to block ads/tracking system-wide through the
use of a hosts file where tracking domains are blocked as such:
`0.0.0.0 trackingdomain.com`

Closes #118 

(Note: I'm not too familliar with the syntax used when setting up the _etc_hosts variable, I may have made a mistake here)

Signed-off-by: Atrate <Atrate@protonmail.com>