### PR TITLE
zshrc: add `NOETCHOSTS` parameter

### DIFF
--- a/doc/grmlzshrc.t2t
+++ b/doc/grmlzshrc.t2t
@@ -100,6 +100,10 @@ A value of zero turns off checking.
 : **NOCOR**
 Non zero values deactivate automatic correction of commands.
 
+: **NOETCHOSTS**
+Non zero values deactivate parsing of "/etc/hosts" disabling host completion
+using file's contents.
+
 : **NOMENU**
 If set to zero (default), allows selection from a menu, if there are at least
 five possible options of completion.

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -481,6 +481,7 @@ setopt unset
 
 # setting some default values
 NOCOR=${NOCOR:-0}
+NOETCHOSTS=${NOETCHOSTS:-0}
 NOMENU=${NOMENU:-0}
 NOPRECMD=${NOPRECMD:-0}
 COMMAND_NOT_FOUND=${COMMAND_NOT_FOUND:-0}
@@ -893,7 +894,7 @@ function grmlcomp () {
     if is42 ; then
         [[ -r ~/.ssh/config ]] && _ssh_config_hosts=(${${(s: :)${(ps:\t:)${${(@M)${(f)"$(<$HOME/.ssh/config)"}:#Host *}#Host }}}:#*[*?]*}) || _ssh_config_hosts=()
         [[ -r ~/.ssh/known_hosts ]] && _ssh_hosts=(${${${${(f)"$(<$HOME/.ssh/known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _ssh_hosts=()
-        [[ -r /etc/hosts ]] && : ${(A)_etc_hosts:=${(s: :)${(ps:\t:)${${(f)~~"$(</etc/hosts)"}%%\#*}##[:blank:]#[^[:blank:]]#}}} || _etc_hosts=()
+        [[ -r /etc/hosts ]] && [[ "$NOETCHOSTS" -eq 0 ]] && : ${(A)_etc_hosts:=${(s: :)${(ps:\t:)${${(f)~~"$(</etc/hosts)"}%%\#*}##[:blank:]#[^[:blank:]]#}}} || _etc_hosts=()
     else
         _ssh_config_hosts=()
         _ssh_hosts=()


### PR DESCRIPTION
`/etc/hosts` may be used as a denylist for undesired hosts on some systems.
In such usage scenarios the file may be large in size and parsing it may severely impact shell startup time.

For example, on a system with `/etc/hosts` from https://github.com/StevenBlack/hosts:

```zsh
% cat profile.zsh
#!/usr/bin/env zsh
zmodload zsh/zprof
source ./etc/zsh/zshrc
zprof
```

```
% ./profile.zsh | head -3
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    1        1181.93  1181.93   87.91%   1181.14  1181.14   87.85%  grmlcomp
```

```
% NOETCHOSTS=1 ./profile.zsh | head -3
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    2          79.77    39.88   47.37%     79.77    39.88   47.37%  compaudit
```