### PR TITLE
zshrc: do not unconditionally overwrite $COLORTERM

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3312,7 +3312,14 @@ zrcautoload lookupinit && lookupinit
 # variables
 
 # set terminal property (used e.g. by msgid-chooser)
-export COLORTERM="yes"
+case "${COLORTERM}" in
+  truecolor)
+    # do not overwrite
+    ;;
+  *)
+    export COLORTERM="yes"
+    ;;
+esac
 
 # aliases
 


### PR DESCRIPTION
Some terminal emulators set COLORTERM=truecolor, do not overwrite those.

Closes: #131