### PR TITLE
zshrc: make ip touch interface lo only

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2677,7 +2677,7 @@ else
 fi
 
 # use ip from iproute2 with color support
-if ip --color=auto addr >/dev/null 2>&1; then
+if ip --color=auto addr show dev lo >/dev/null 2>&1; then
     alias ip='command ip --color=auto'
 fi
 


### PR DESCRIPTION
This reduces cpu cycles, but interface `lo` has to be available
for the check to succeed.