### PR TITLE
Fix make succeeding when the recipe fails

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,13 +7,14 @@ all: $(MANPAGES) $(HTMLPAGES)
 .SUFFIXES: .t2t .5 .html
 
 .t2t.5:
-	@printf 'TXT2TAGS %s > %s\n' "$<" "$@"
-	@txt2tags --target man -o- $< | sed -e '/^$$/d' -e 's/^\\e$$//' > $@
+	@printf 'TXT2TAGS %s -> %s\n' "$<" "$@"
+	@txt2tags --target man -q -o $@ $<
+	@sed -e '/^$$/d' -e 's/^\\e$$//' -i~ $@
 
 .t2t.html:
-	@printf 'TXT2TAGS %s > %s\n' "$<" "$@"
-	@txt2tags --target html --style t2t-modern.css -o- $< \
-| sed -e '/^$$/d' -e 's/^\\$$//' > $@
+	@printf 'TXT2TAGS %s -> %s\n' "$<" "$@"
+	@txt2tags --target html --style t2t-modern.css -q -o $@ $<
+	@sed -e '/^$$/d' -e 's/^\\$$//' -i~ $@
 
 clean:
 	rm -f *.5 *.html *.gz *~


### PR DESCRIPTION
The current `doc/Makefile` has "successfully" created empty man pages on (Arch-ish) MSYS2. See the original issue [here](https://github.com/msys2/MSYS2-packages/pull/2847).

Without a working `txt2tags`, the recipes that generate the grml-zsh-config docs print an error, but `make` succeeds anyway. This is because the error returned to make is from the last tool in the pipeline, regardless of any failing or even absent tools preceding; see [here](https://unix.stackexchange.com/q/16702).

Also, redirecting a failing command to target (i.e. `> $@`) even without a pipeline is problematic without the GNUish `.DELETE_ON_ERROR:` rule, see [here](https://unix.stackexchange.com/q/16177) (empty build targets are generated, and so will mistakenly succeed on next invocation of `make`).

To mitigate both these case, I went with [this](https://stackoverflow.com/a/5347452) approach. These changes could affect portability in ways I'm not aware, if so please advise.