### PR TITLE
tmux.conf: source user-specific local conf file ~/.tmux.conf.local

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -26,7 +26,7 @@ bind-key j join-pane -s !
 bind-key B if-shell "! tmux has-session -t bg" "new-session -d -s bg" \; move-window -t bg
 
 ### Reload Config
-bind-key R source-file ~/.tmux.conf \; display-message "~/.tmux.conf reloaded"
+bind-key R source-file ~/.tmux.conf \; source-file -q ~/.tmux.conf.local \; display-message "~/.tmux.conf[.local] reloaded"
 
 ###rebind keys
 bind-key h next-layout
@@ -62,3 +62,6 @@ set -g status-right '#[fg=yellow]%Y-%m-%d %H:%M'
 
 set-window-option -g window-status-style fg=blue,bg=black
 set-window-option -g window-status-current-style bold
+
+### source user-specific local configuration file
+source-file -q ~/.tmux.conf.local


### PR DESCRIPTION
To manage a user-specific local configuration file (like in Grml's
'.vimrc.conf' + '.zshrc.conf') we need to source '~/.tmux.conf.local'.

"bind-key R" (Reload Config) does now reload the 'main" config file
'\~/.tmux.conf' and the user-specific local configuration file
'~/.tmux.conf.local'.

With 'source-file -q', no error will be returned if the file does not exist.