### PR TITLE
tmux.conf: Add bind-key J to join marked pane to active window

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -22,6 +22,10 @@ bind-key '\' confirm-before kill-session
 ### join the last active pane to the currently active window
 bind-key j join-pane -s !
 
+### join the marked pane to the currently active window
+### ('bind-key m select-pane -m' is default to mark the current pane)
+bind-key J join-pane
+
 ### Move current window to session named "bg" (and create session if it does not exist)
 bind-key B if-shell "! tmux has-session -t bg" "new-session -d -s bg" \; move-window -t bg
 


### PR DESCRIPTION
We have "bind-key j" which joins "the last active pane to the currently
active window". This is cool, if you are able to directly jump to the
window where the pane should go to. Old people like me do not remember
the window (number) where they came from and skim around until they find
the window in question, try to remember the window number, jump back and
forth from window with the needed pane and finally "join the last active
pane to the currently active window".

This is a bit cumbersome, but with "bind-key m" it is possible to
mark the pane in question, skim around until one fine the window where
the pane belongs and "join the marked pane to the currently active
window".