### PR TITLE
zshrc: run tlog alias with --follow=name

### DIFF
--- a/doc/grmlzshrc.t2t
+++ b/doc/grmlzshrc.t2t
@@ -1106,7 +1106,7 @@ http://www.cl.cam.ac.uk/~mgk25/unicode.html#term).
 Sets mode from ISO 2022 to UTF-8 (See:
 http://www.cl.cam.ac.uk/~mgk25/unicode.html#term).
 
-: **tlog** (//tail -f /var/log/syslog//)
+: **tlog** (//tail --follow=name /var/log/syslog//)
 Prints syslog continuously (See tail(1)).
 
 : **up** (//aptitude update ; aptitude safe-upgrade//)

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2848,7 +2848,7 @@ if [ -e /var/log/syslog ] ; then
   #a1# Take a look at the syslog: \kbd{\$PAGER /var/log/syslog || journalctl}
   salias llog="$PAGER /var/log/syslog"     # take a look at the syslog
   #a1# Take a look at the syslog: \kbd{tail -f /var/log/syslog || journalctl}
-  salias tlog="tail -f /var/log/syslog"    # follow the syslog
+  salias tlog="tail --follow=name /var/log/syslog"    # follow the syslog
 elif check_com -c journalctl ; then
   salias llog="journalctl"
   salias tlog="journalctl -f"


### PR DESCRIPTION
It's annoying to follow the syslog, but then tools like logroate kicking in to rename syslog to syslog.1. Then you're stuck with the "old" syslog file content, by using the --follow=name option we can fix this.

Quoting from tail(1):

```
With --follow (-f), tail defaults to following the file descriptor, which means that even
if a tail'ed file is renamed, tail will continue | to track its end. This default behavior
is not desirable when you really want to track the actual name of the file, not the
file descriptor (e.g., log rotation). Use --follow=name in that case. That causes tail
to track the named file in a way that accommodates renaming, removal and creation.
```