### PR TITLE
tmux.conf: detect running as tmate and disable non-supported features

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -30,7 +30,8 @@ bind-key J join-pane
 bind-key B if-shell "! tmux has-session -t bg" "new-session -d -s bg" \; move-window -t bg
 
 ### Reload Config
-bind-key R source-file ~/.tmux.conf \; source-file -q ~/.tmux.conf.local \; display-message "~/.tmux.conf[.local] reloaded"
+if-shell "! (env | grep -q TMUX=/tmp/tmate)" \
+  "bind-key R source-file ~/.tmux.conf \\; source-file -q ~/.tmux.conf.local \\; display-message '~/.tmux.conf[.local] reloaded'"
 
 ###rebind keys
 bind-key h next-layout
@@ -68,4 +69,5 @@ set-window-option -g window-status-style fg=blue,bg=black
 set-window-option -g window-status-current-style bold
 
 ### source user-specific local configuration file
-source-file -q ~/.tmux.conf.local
+if-shell "! (env | grep -q TMUX=/tmp/tmate)" \
+  "source-file -q ~/.tmux.conf.local"


### PR DESCRIPTION
tmux versions >=2.3 support the -q option for source-file to suppress errors for nonexistent files. Even Debian/oldoldstable has tmux v2.3-4, so this works nice everwhere, *except* for when invoking tmate, which is a fork based on an old version of tmux, which then complains about:

| /etc/tmux.conf:75: usage: source-file path
| /etc/tmux.conf:36: usage: source-file path

Try to detect tmate from within the environment, and then enable the configuration only when *not* running from within tmate.

This commit relies on @mika's commit grml/grml-etc-core@71101e0 (the commit message was shamelessly copied, thx!), but two things changed:

* Use `! (env | grep -q TMUX=/tmp/tmate)` instead of `env | grep -q TMUX=/tmp/tmate && false` which always results in false:

  $ true && false; echo $?
  1

* Double escape the semicolon (;) (i.e. \\;).

  Because if bind-key is set up to call multiple commands, each command needs to be separated with \;. (Each command is terminated by a newline or a semicolon. Commands separated by semicolons together form a ‘command sequence’). And if bind-key is called within if-shell \; needs to be escaped one more time. (No escaping would have been needed when using braces ({}), but tmate does not seem to support braces.)

  See: COMMAND PARSING AND EXECUTION + PARSING SYNTAX in man page tmux(1).

Replaces the PR: grml/grml-etc-core#151