### PR TITLE
WIP: Replace ip-screen with hostname -I + sed

### DIFF
--- a/etc/grml/screenrc
+++ b/etc/grml/screenrc
@@ -6,7 +6,7 @@
 ################################################################################
 
   backtick 1 0 60   /usr/bin/cpu-screen
-  backtick 2 0 60   /usr/bin/ip-screen
+  backtick 2 0 60   sh -c "hostname -I | sed -e 's/ [\^ ]*:.*$//;s/ / | /g;s/ | $//'"
   caption always "%{+b rk}$USER@%{wk}%H | %{yk}(load: %l |%{rk} cpu: %1` | %{Gk}net: %2`)  %-21=%{wk}%D %Y-%m-%d %0c"
   hardstatus alwayslastline "%{wr}%n%f %t %{kw} | %?%-Lw%?%{wb}%n*%f %t%?(%u)%?%{kw}%?%+Lw%? %{wk}"
 


### PR DESCRIPTION
In grml/grml-scripts-core#3 we discussed and decided to rewrite cpu-screen in Perl and drop ip-screen (and other scripts) to make grml-scripts-core fit for ARM.

After some benchmarking of the Perl script implementations of ip-screen, we finally decided to go for `hostname -I` + sed to get the same output as ip-screen.

So we need to replace ip-screen with hostname -I + sed in our screenrc as well. The command to get a drop-in replacement for ip-screen looks like this:

    % hostname -I | sed -e 's/ [^ ]*:.*$//;s/ / | /g;s/ | $//'

Unfortunately we need "sh -c" to allow piping and also need to escape `^` with `\^`. Not sure why, the GNU/screen documentation does only mention `%` for "String Escapes" (see: https://www.gnu.org/software/screen/manual/screen.html#String-Escapes)

I am not sure, if we should keep ip-screen as a wrapper script (which might allow us, to use the output for other things).

Open for discussion. /cc @mika + @zeha 