### PR TITLE
MAKEDEV is gone from Debian, drop WRITE_ON_UDEV

### DIFF
--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -126,8 +126,5 @@ export READNULLCMD=${PAGER:-/usr/bin/pager}
 # allow zeroconf for distcc
 export DISTCC_HOSTS="+zeroconf"
 
-# MAKEDEV should be usable on udev as well by default:
-export WRITE_ON_UDEV=yes
-
 ## END OF FILE #################################################################
 # vim:filetype=zsh foldmethod=marker autoindent expandtab shiftwidth=4


### PR DESCRIPTION
http://bugs.debian.org/1064931

mknod should be used directly instead.