### PR TITLE
zshenv: add ~/.local/bin to default PATH

### DIFF
--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -81,6 +81,7 @@ esac
 if (( EUID != 0 )); then
   path=(
     $HOME/bin
+    $HOME/.local/bin
     /usr/local/bin
     /usr/bin
     /bin
@@ -95,6 +96,7 @@ if (( EUID != 0 )); then
 else
   path=(
     $HOME/bin
+    $HOME/.local/bin
     /usr/local/sbin
     /usr/local/bin
     /sbin


### PR DESCRIPTION
Various modern "language-level" package managers put programs they install into that directory.