### PR TITLE
zshrc: increase HISTSIZE + SAVEHIST to our defaults also for live system

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1681,12 +1681,8 @@ function command_not_found_handler () {
 
 #v#
 HISTFILE=${HISTFILE:-${ZDOTDIR:-${HOME}}/.zsh_history}
-if [[ -z "${HISTSIZE}" ]]; then
-  isgrmlcd && HISTSIZE=500  || HISTSIZE=5000
-fi
-if [[ -z "${SAVEHIST}" ]]; then
-  isgrmlcd && SAVEHIST=1000 || SAVEHIST=10000 # useful for setopt append_history 
-fi
+HISTSIZE=${HISTSIZE:-5000}
+SAVEHIST=${SAVEHIST:-10000}  # useful for setopt append_history
 
 # dirstack handling
 


### PR DESCRIPTION
Otherwise it might be actually unexpected for some users of the Grml live system, so use same defaults for live system as for non-live systems.

While at it, switch to the foo=${foo:-default} style as suggested by Frank Terbeck in https://github.com/grml/grml-etc-core/issues/160 - thanks!

FTR: maybe we want to even further increase the defaults? (Personally I've set it to `10000000` on my own systems, not sure it's relevant memory wise or so?)