### PR TITLE
zshrc: set HISTSIZE + SAVEHIST only if not yet set or being set to zsh upstream default

### DIFF
--- a/doc/grmlzshrc.t2t
+++ b/doc/grmlzshrc.t2t
@@ -90,8 +90,7 @@ grml-small.
 Where zsh saves the history. Default: ${HOME}/.zsh_history.
 
 : **HISTSIZE**
-Number of commands to be kept in the history. On a Grml-CD this defaults to
-500, on a hard disk installation to 5000.
+Number of commands to be kept in the history. Default: 5000
 
 : **MAILCHECK**
 Sets the frequency in seconds for zsh to check for new mail. Defaults to 30.
@@ -117,8 +116,7 @@ Show time (user, system and cpu) used by external commands, if they run longer
 than the defined number of seconds (default: 5).
 
 : **SAVEHIST**
-Number of commands to be stored in ${HISTFILE}. Defaults to 1000 on a Grml-CD
-and to 10000 on an installation on hard disk.
+Number of commands to be stored in ${HISTFILE}. Default: 10000
 
 : **watch**
 As in tcsh(1) an array of login/logout events to be reported by the shell

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1681,8 +1681,11 @@ function command_not_found_handler () {
 
 #v#
 HISTFILE=${HISTFILE:-${ZDOTDIR:-${HOME}}/.zsh_history}
-isgrmlcd && HISTSIZE=500  || HISTSIZE=5000
-isgrmlcd && SAVEHIST=1000 || SAVEHIST=10000 # useful for setopt append_history
+# override settings only if the defaults from zsh are in place
+if [[ -z $HISTSIZE || $HISTSIZE -eq 30 ]] ; then
+  HISTSIZE=5000
+  SAVEHIST=10000  # useful for setopt append_history
+fi
 
 # dirstack handling
 


### PR DESCRIPTION
In commit 7465ffb0803b0eb05d808b850088e90572c8dacd we adjusted the behavior when HISTSIZE and/or SAVEHIST are unset. Though this broke existing setups where HISTSIZE and SAVEHIST was not yet set (like in /etc/profile.d as reported in #160), as zsh sets HISTSIZE and SAVEHIST by default:

```
  config.h.in:#define DEFAULT_HISTSIZE 30
  configure.ac:#define DEFAULT_HISTSIZE 30
```

So `zsh -f` defaults to $HISTSIZE of 30 and $SAVEHIST of 0, Now we clearly want to ship better defaults than this. Do this, by checking whether is HISTSIZE is unset or set to the upstream default (being 30), only then set HISTSIZE and SAVEHIST.

In commit 81096c8f57c088163cfcea49f2eb03b4b44c66fd we increased HISTSIZE + SAVEHIST also for our live system usage, re-apply this change.

Closes: https://github.com/grml/grml-etc-core/issues/160 and https://github.com/grml/grml-etc-core/issues/169