### PR TITLE
Drop DISTCC_HOSTS variable

### DIFF
--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -125,8 +125,5 @@ unset lp
 
 export READNULLCMD=${PAGER:-/usr/bin/pager}
 
-# allow zeroconf for distcc
-export DISTCC_HOSTS="+zeroconf"
-
 ## END OF FILE #################################################################
 # vim:filetype=zsh foldmethod=marker autoindent expandtab shiftwidth=4


### PR DESCRIPTION
Assume that people using distcc can and want to configure it themselves.

This was set in `zshenv`, which we need to tidy up.