### PR TITLE
zshenv: stop setting HOSTNAME

### DIFF
--- a/etc/zsh/zshenv
+++ b/etc/zsh/zshenv
@@ -25,13 +25,6 @@
 # no xsource() here because it's only created in zshrc! (which is good)
 [[ -r /etc/environment ]] && source /etc/environment
 
-# set environment variables (important for autologin on tty)
-if [ -n "${HOSTNAME}" ] ; then
-    export HOSTNAME="${HOSTNAME}"
-else
-    export HOSTNAME="$(uname -n)"
-fi
-
 # make sure /usr/bin/id is available
 if [[ -x /usr/bin/id ]] ; then
     [[ -z "$USER" ]]          && export USER=$(/usr/bin/id -un)


### PR DESCRIPTION
In a normal zsh environment this variable is called HOST, and is automatically set.