### PR TITLE
zshrc: use path_helper on macOS

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -545,10 +545,12 @@ check_com -c dircolors && eval $(dircolors -b)
 isdarwin && export CLICOLOR=1
 isfreebsd && export CLICOLOR=1
 
-# do MacPorts setup on darwin
+# Setup PATH from system defaults on macOS.
+if [[ -x /usr/libexec/path_helper ]]; then
+    eval $(/usr/libexec/path_helper -s)
+fi
+# Add MacPorts PATH on darwin/macOS.
 if isdarwin && [[ -d /opt/local ]]; then
-    # Note: PATH gets set in /etc/zprofile on Darwin, so this can't go into
-    # zshenv.
     PATH="/opt/local/bin:/opt/local/sbin:$PATH"
     MANPATH="/opt/local/share/man:$MANPATH"
 fi

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -552,8 +552,6 @@ if isdarwin && [[ -d /opt/local ]]; then
     PATH="/opt/local/bin:/opt/local/sbin:$PATH"
     MANPATH="/opt/local/share/man:$MANPATH"
 fi
-# do Fink setup on darwin
-isdarwin && xsource /sw/bin/init.sh
 
 # load our function and completion directories
 for fdir in /usr/share/grml/zsh/completion /usr/share/grml/zsh/functions; do


### PR DESCRIPTION
macOS provides a system-wide PATH configuration. For that to work, login shells need to evaluate `path_helper -s`. Add this.
