### PR TITLE
zshrc: remove "hbp" alias

### DIFF
--- a/doc/grmlzshrc.t2t
+++ b/doc/grmlzshrc.t2t
@@ -956,9 +956,6 @@ Shows grep output in nice colors, if available.
 : **grml-version** (//cat /etc/grml_version//)
 Prints version of running grml.
 
-: **hbp** (//hg-buildpackage//)
-Helper program to maintain Debian packages with mercurial.
-
 : **insecscp** (//scp -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null"//)
 scp with possible man-in-the-middle attack enabled. This is convenient, if the targets
 host key changes frequently, for example on virtualized test- or development-systems.

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3568,10 +3568,6 @@ if check_com -c hg ; then
         for i in $(hg status -marn "$@") ; diff -ubwd <(hg cat "$i") "$i"
     }
 
-    # build debian package
-    #a2# Alias for \kbd{hg-buildpackage}
-    alias hbp='hg-buildpackage'
-
     # execute commands on the versioned patch-queue from the current repos
     [[ -n "$GRML_NO_SMALL_ALIASES" ]] || alias mq='hg -R $(readlink -f $(hg root)/.hg/patches)'
 


### PR DESCRIPTION
The target program (hg-buildpackage) does not exist anymore.