### PR TITLE
zshrc: deprecate xunfunction

### DIFF
--- a/doc/grmlzshrc.t2t
+++ b/doc/grmlzshrc.t2t
@@ -858,6 +858,7 @@ arguments for details.
 
 : **xunfunction()**
 Removes the functions salias, xcat, xsource, xunfunction and zrcautoload.
+**Deprecated.**
 
 : **zrcautoload()**
 Wrapper around the autoload builtin. Loads the definitions of functions

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -490,11 +490,13 @@ function xcat () {
 }
 
 # Remove these functions again, they are of use only in these
-# setup files. This should be called at the end of .zshrc.
+# setup files.
 function xunfunction () {
     emulate -L zsh
     local -a funcs
     local func
+    # TODO: Remove xunfunction in 2025.
+    echo "W: xunfunction is deprecated. Please remove it from your configuration."
     funcs=(salias xcat xsource xunfunction zrcautoload zrcautozle)
     for func in $funcs ; do
         [[ -n ${functions[$func]} ]] \


### PR DESCRIPTION
It was introduced in commit 3d6452fdfc44310b5615eaf61c95cab4c27d9bf8 in 2007, and 724508d30c788da653579d44ac3566f27ffed1d6 in 2008 tried to remove it. The remove was reverted in 347c7def8583733dd8f8440214af25fbaf89666f in 2008.

Let's try this again, this time with a deprecation warning.

Addresses #183.