### PR TITLE
zshrc: Add alias llblk for lsblk with useful columns

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3147,6 +3147,9 @@ alias insecssh='ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/nu
 #a2# scp with StrictHostKeyChecking=no \\&\quad and UserKnownHostsFile unset
 alias insecscp='scp -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null"'
 
+#a2# lsblk (list block devices) with the most useful columns
+alias llblk="lsblk -o +LABEL,PARTLABEL,UUID,FSTYPE,SERIAL"
+
 # useful functions
 
 #f5# Backup \kbd{file_or_folder {\rm to} file_or_folder\_timestamp}


### PR DESCRIPTION
TBH: I am not sure about the `#a2#` tag in the comment above. I just copied the comment from above.

The comment for `#a#` is not perfectly clear for me:
https://github.com/grml/grml-etc-core/blob/e2a5cafd7db6c24c72cac370bb073850b0a762f7/etc/zsh/zshrc#L42-L45