### PR TITLE
tmux: Increase maximum status-right length to 64

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -62,6 +62,7 @@ set -g status-left "#[fg=white]@#h#[fg=red]:#S#[fg=white] |"
 #set -g status-right-length 16
 #set -g status-right '#[fg=yellow]%Y-%m-%d %H:%M'
 ### status-right: IPs and Date and Time
+set -g status-right-length 64
 if-shell "command -v hostname && hostname --help | grep -q -- -I" { set -g status-right "#[fg=green](net: #(hostname -I | sed -e 's/ [^ ]*:.*$//;s/ / | /g;s/ | $//')) #[fg=yellow]%Y-%m-%d %H:%M" } { set -g status-right '#[fg=yellow]%Y-%m-%d %H:%M' }
 ### status-right: Time
 #set -g status-right-length 6


### PR DESCRIPTION
With the new IP address display in status-right, the default value for status-right-length (40 characters) is not sufficient.

Two regular IPv4 addresses can easily exceed the 40 character limit. 64 characters ought to be enough for anybody.

On a server with two private range IPv4 addresses, the right status is truncated to something like this:
```
(net: 192.168.1.234 | 192.168.123.4) 202
```

Expected output:
```
(net: 192.168.1.234 | 192.168.123.4) 2025-05-16 19:10
```

Just for reference: The expected output line has 54 characters.