### PR TITLE
zshrc: allow disabling macOS `path_helper`

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -350,6 +350,7 @@ setopt unset
 NOCOR=${NOCOR:-0}
 NOETCHOSTS=${NOETCHOSTS:-0}
 NOMENU=${NOMENU:-0}
+NOPATHHELPER=${NOPATHHELPER:-0}
 NOPRECMD=${NOPRECMD:-0}
 COMMAND_NOT_FOUND=${COMMAND_NOT_FOUND:-0}
 GRML_ZSH_CNF_HANDLER=${GRML_ZSH_CNF_HANDLER:-/usr/share/command-not-found/command-not-found}
@@ -541,7 +542,7 @@ export MAIL=${MAIL:-/var/mail/$USER}
 check_com -c dircolors && eval $(dircolors -b)
 
 # Setup PATH from system defaults on macOS.
-if [[ -x /usr/libexec/path_helper ]]; then
+if [[ -x /usr/libexec/path_helper ]] && [[ "$NOPATHHELPER" -eq 0 ]] ; then
     eval $(/usr/libexec/path_helper -s)
 fi
 # Add MacPorts PATH on darwin/macOS.


### PR DESCRIPTION
After recently updating `grml` zsh config (among other things) on macOS it took me a while to figure out why tools on my `PATH` were acting strange.
Turned out the reason is #175 - `path_helper` is now called in `zshrc`, which breaks setups modifying `PATH` in `zprofile` or earlier (in my case https://github.com/nix-darwin/nix-darwin and `nix shell` functionality), because `path_helper` *prepends* its paths in `PATH`, making it impossible to e.g. use other `git` executable than provided by the OS without modifying `PATH` *after* loading `grml` zshrc.

Personally, I think `zprofile` is a better fit for `path_helper`, but regardless of where one adds this logic, users should be able to disable it (e.g. if already done externally), which is what I'm adding in this PR.