### PR TITLE
zshrc: export all locale variables

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -519,7 +519,7 @@ if (( ZSH_NO_DEFAULT_LOCALE == 0 )); then
     xsource "/etc/default/locale"
 fi
 
-for var in LANG LC_ALL LC_MESSAGES ; do
+for var in LANG LANGUAGE LC_ALL LC_COLLATE LC_CTYPE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_TIME ; do
     [[ -n ${(P)var} ]] && export $var
 done
 builtin unset -v var


### PR DESCRIPTION
Previously only LANG LC_ALL LC_MESSAGES were exported. I assume the historic reason is that grml-setlang used to set up exactly these three variables in /etc/default/locale. With the new grml-setlang changes LC_COLLATE LC_TIME can also be set. Lets support all variables so this is not specific to grml-setlang.