### PR TITLE
Unregister /etc/network/interfaces.examples as a conffile

### DIFF
--- a/debian/grml-etc-core.maintscript
+++ b/debian/grml-etc-core.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/network/interfaces.examples 0.19.20~


### PR DESCRIPTION
Removed in 5b64711912051504b84cce8ab028a6a26bd58948.
