### PR TITLE
Remove checkhome hack

### DIFF
--- a/doc/grmlzshrc.adoc
+++ b/doc/grmlzshrc.adoc
@@ -667,10 +667,6 @@ Returns true if given command exists either as program, function, alias,
 builtin or reserved word. If the option -c is given, only returns true,
 if command is a program.
 
-*checkhome()*::
-Changes directory to $HOME on first invocation of zsh. This is necessary on
-Grml systems with autologin.
-
 *cl()*::
 Changes current directory to the one supplied by argument and lists the files
 in it, including file names starting with ".".

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -224,16 +224,6 @@ function isutfenv () {
 # check for user, if not running as root set $SUDO to sudo
 (( EUID != 0 )) && SUDO='sudo' || SUDO=''
 
-# change directory to home on first invocation of zsh
-# important for rungetty -> autologin
-# Thanks go to Bart Schaefer!
-isgrml && function checkhome () {
-    if [[ -z "$ALREADY_DID_CD_HOME" ]] ; then
-        export ALREADY_DID_CD_HOME=$HOME
-        cd
-    fi
-}
-
 # check for zsh v5.1+
 
 if ! [[ ${ZSH_VERSION} == 5.<1->*        \
@@ -2654,7 +2644,6 @@ function grmlstuff () {
 }
 
 # now run the functions
-isgrml && checkhome
 isgrml && grmlstuff
 grmlcomp
 


### PR DESCRIPTION
Since grml/grml-live#247 grml/grml-live@61be58509c5bbc5401806003bda83768818d552d the initial CWD is set by systemd to HOME.

The rungetty/autologin workaround can thus go away.

Closes: grml/grml-etc-core#180