### PR TITLE
zshrc: add special code for cdt() for FreeBSD

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3200,10 +3200,16 @@ function mkcd () {
 
 #f5# Create temporary directory and \kbd{cd} to it
 function cdt () {
-       local -a cdttemplate
-       [ "$#" -eq 1 ] && cdttemplate=(-t "$1".XXXXXXX)
-       builtin cd "$(mktemp -d ${cdttemplate[@]})"
-       builtin pwd
+    local -a cdttemplate
+    if isfreebsd; then
+        # mktemp(1) on FreeBSD doesn't behave the same, cf.
+        # https://man.freebsd.org/cgi/man.cgi?query=mktemp#OPTIONS
+        [ "$#" -eq 1 ] && cdttemplate=(-t "$1")
+    else
+        [ "$#" -eq 1 ] && cdttemplate=(-t "$1".XXXXXXX)
+    fi
+    builtin cd "$(mktemp -d ${cdttemplate[@]})"
+    builtin pwd
 }
 
 #f5# List files which have been accessed within the last {\it n} days, {\it n} defaults to 1


### PR DESCRIPTION
While there, fix whitespace

---

Sample session:

```
root@fbsd ~ # which cdt
cdt () {
        local -a cdttemplate
        if isfreebsd
        then
                [ "$#" -eq 1 ] && cdttemplate=(-t "$1") 
        else
                [ "$#" -eq 1 ] && cdttemplate=(-t "$1".XXXXXXX) 
        fi
        builtin cd "$(mktemp -d ${cdttemplate[@]})"
        builtin pwd
}
root@fbsd ~ # cdt grml
/tmp/grml.12PvXj6sxe
root@fbsd /tmp/grml.12PvXj6sxe # uname -a
FreeBSD fbsd.local 14.2-RELEASE-p1 FreeBSD 14.2-RELEASE-p1 GENERIC amd64
```

Improves #203 