### PR TITLE
Fix chpwd error when DIRSTACKSIZE is unset by Claude Code

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1537,6 +1537,7 @@ if zstyle -T ':grml:chpwd:dirstack' enable; then
 
     function chpwd () {
         (( ZSH_SUBSHELL )) && return
+        [[ -z $DIRSTACKSIZE ]] && return
         (( $DIRSTACKSIZE <= 0 )) && return
         [[ -z $DIRSTACKFILE ]] && return
         grml_dirstack_filter $PWD && return


### PR DESCRIPTION
Add null check for DIRSTACKSIZE variable before numeric comparison to prevent shell errors when Claude Code unsets the environment variable.

🤖 Generated with [Claude Code](https://claude.ai/code)