### PR TITLE
Remove unused code from script-functions

### DIFF
--- a/etc/grml/script-functions
+++ b/etc/grml/script-functions
@@ -103,16 +103,6 @@ checkbootparam(){
 }
 # }}}
 
-# {{{ check whether $1 is yes
-checkvalue(){
-  if [ "$1" = "yes" -o "$1" = "YES" ] ; then
-    return 0
-  else
-    return 1
-  fi
-}
-# }}}
-
 # {{{ grml specific checks
 isgrml(){
   [ -f /etc/grml_version ] && return 0 || return 1


### PR DESCRIPTION
I imagine when we move the remaining scripts from grml-scripts into grml-live, `script-functions` should be merged with `autoconfig.functions`. Until then we can at least slim this file down.