### PR TITLE
d/man fix missing grmlzshrc.5

### DIFF
--- a/debian/grml-etc-core.manpages
+++ b/debian/grml-etc-core.manpages
@@ -1,1 +1,2 @@
+doc/grmlzshrc.5
 manpages/*.1

--- a/debian/manpages
+++ b/debian/manpages
@@ -1,1 +1,0 @@
-doc/grmlzshrc.5


### PR DESCRIPTION
 * debhelper didn't touch d/manpages in favour of d/grml-etc-core.manpages so we need to move all manpages to the later.