### PR TITLE
zshrc: switch to myip.grml.org with IPv6 support, options -4 + -6 to force respective protocols

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -3443,9 +3443,14 @@ function _simple_extract () {
 compdef _simple_extract simple-extract
 [[ -n "$GRML_NO_SMALL_ALIASES" ]] || alias se=simple-extract
 
-#f5# Show "public" IPv4 address of current system on stdout. Requires network access and curl(1).
+#f5# Show "public" IP address of current system on stdout. Requires network access and curl(1).
 function myip () {
-    curl http://v4.showip.spamt.net/ -H 'User-Agent: grml-etc-core-zshrc'
+    if [[ $# == 0 ]] || [[ $# == 1 && $1 == "-4" ]] || [[ $# == 1 && $1 == "-6" ]] ; then
+        curl "$@" https://myip.grml.org -H 'User-Agent: grml-etc-core-zshrc'
+    else
+        printf 'usage: myip [-4|-6]\n' >&2
+        return 1
+    fi
 }
 
 #f5# Change the xterm title from within GNU-screen


### PR DESCRIPTION
http://v4.showip.spamt.net/ is down since at least 2026-01-11:

```
  % myip
  <html>
  <head><title>502 Bad Gateway</title></head>
  <body>
  <center><h1>502 Bad Gateway</h1></center>
  <hr><center>nginx/1.24.0 (Ubuntu)</center>
  </body>
  </html>
```

We decided to implement our own solution, to not leak IP addresses to any foreign services. While doing so, add support for IPv6, and also support the "-4" + "-6" command line options, to explicitly request IPv4 + IPv6 addresses.

Closes: grml/grml-etc-core/issues/237