### PR TITLE
change formatting of final 'if-shell' command to be compatible with tpm

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -71,5 +71,6 @@ set-window-option -g window-status-style fg=blue,bg=black
 set-window-option -g window-status-current-style bold
 
 ### source user-specific local configuration file
-if-shell "! (env | grep -q TMUX=/tmp/tmate)" \
-  "source-file -q ~/.tmux.conf.local"
+if-shell "! (env | grep -q TMUX=/tmp/tmate)" {
+  source-file -q ~/.tmux.conf.local
+}


### PR DESCRIPTION
After the changes introduced in PR #152, [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) will no longer work when loaded from within ~/.tmux.conf.local. The result is that #152 requires one to either move their tpm plugin configuration to .tmux.conf (which defeats the purpose of isolating user modications to .tmux.conf.local), or to change the formatting of the final 'if-shell' command.

Closes #244