### PR TITLE
tmux.conf: add 'notes' to bind-key commands

### DIFF
--- a/etc/tmux.conf
+++ b/etc/tmux.conf
@@ -42,6 +42,23 @@ bind-key tab select-pane -t :.+
 bind-key | command-prompt -p "exec:" "split-window -h '%%'"
 bind-key - command-prompt -p "exec:" "split-window -v '%%'"
 
+%if #{>=:#{version},3.1}
+bind-key -N 'Select the last (previously selected) window' C-a last-window
+bind-key -N 'Select the next window' space next-window
+bind-key -N 'Select the next window' C-space next-window
+bind-key -N 'Kill pane (with confirmation)' K confirm-before kill-pane
+bind-key -N 'Kill session (with confirmation)' '\' confirm-before kill-session
+bind-key -N 'Join the last active pane to the currently active window' j join-pane -s !
+bind-key -N 'Join the marked pane to the currently active window' J join-pane
+bind-key -N 'Move current window to session named "bg" (and create session if it does not exist)' B if-shell "! tmux has-session -t bg" "new-session -d -s bg" \; move-window -t bg
+bind-key -N 'Reload config' R source-file ~/.tmux.conf \; source-file -q ~/.tmux.conf.local \; display-message '~/.tmux.conf[.local] reloaded'
+bind-key -N 'Select the next layout' h next-layout
+bind-key -N 'Select the previous window' BSpace previous-window
+bind-key -N 'Select next pane' tab select-pane -t :.+
+bind-key -N 'Split window horizontally & prompt for command' | command-prompt -p "exec:" "split-window -h '%%'"
+bind-key -N 'Split window vertically & prompt for command' - command-prompt -p "exec:" "split-window -v '%%'"
+%endif
+
 ### misc options
 set -s escape-time 0
 set -g default-terminal "screen-256color"


### PR DESCRIPTION
`<prefix>?` in tmux only displays keys that have an attached note; therefore, none of the key bindings within gmrl's tmux.cfg appear on this key binding list. This PR adds these missing notes to each `bind-key` command.