### PR TITLE
Support screen 5.0

### DIFF
--- a/debian/grml-etc-core.links
+++ b/debian/grml-etc-core.links
@@ -1,2 +1,3 @@
 /usr/share/man/man1/grml-scripts-core.1.gz /usr/share/man/man1/cpu-screen.1.gz
 /usr/share/man/man1/grml-scripts-core.1.gz /usr/share/man/man1/ip-screen.1.gz
+/usr/share/man/man1/grml-scripts-core.1.gz /usr/share/man/man1/loadavg-screen.1.gz

--- a/etc/grml/screenrc
+++ b/etc/grml/screenrc
@@ -38,11 +38,6 @@
 
 # shell                 /bin/zsh
 
-# "sorendition": set the colors for
-# the "messages" and "text marking"
-# (ie text you mark in copy mode):
-  sorendition 10 99 # default!
-
 # use %n to display the window number and %t for its title:
   activity              "activity in %n (%t) [%w:%s]~"
 

--- a/etc/grml/screenrc
+++ b/etc/grml/screenrc
@@ -21,7 +21,6 @@
 # defsilence            off             # default: off
 # hardcopy_append       on              # default: off
   hardcopy_append       off             # default: off
-  nethack               on              # default: off
 # don't display the copyright page
   startup_message       off             # default: on
 # no annoying audible bell, please

--- a/etc/grml/screenrc
+++ b/etc/grml/screenrc
@@ -5,14 +5,15 @@
 # License:       This file is licensed under the GPL v2.
 ################################################################################
 
-  backtick 1 0 60   /usr/bin/cpu-screen
-  backtick 2 0 60   /usr/bin/ip-screen
-  caption always "%{+b rk}$USER@%{wk}%H | %{yk}(load: %l |%{rk} cpu: %1` | %{Gk}net: %2`)  %-21=%{wk}%D %Y-%m-%d %0c"
-  hardstatus alwayslastline "%{wr}%n%f %t %{kw} | %?%-Lw%?%{wb}%n*%f %t%?(%u)%?%{kw}%?%+Lw%? %{wk}"
+  backtick 1 0 60   /usr/bin/loadavg-screen
+  backtick 2 0 60   /usr/bin/cpu-screen
+  backtick 3 0 60   /usr/bin/ip-screen
+  caption always "%{b1;0}$USER@%{b7;0}%H | %{b3;0}(load:%1` |%{b1;0} cpu: %2` | %{b2;0}net: %3`) %=%{b7;0}%D %Y-%m-%d %0c "
+  hardstatus alwayslastline "%{1;7}%n%f %t %{7;0} | %-Lw%{4;7}%n%f %t%?(%u)%?%{7;0}%+Lw%="
 
 # switch order of caption and hardstatus:
-#  hardstatus alwayslastline "%{+b kr}$USER@%{kw}%H | %{ky}(load: %l |%{kr} cpu: %1` | %{kG}net: %2`)  %-21=%{kw}%D %Y-%m-%d %0c"
-#  caption always "%{rw}%n%f %t %{wk} | %?%-Lw%?%{bw}%n*%f %t%?(%u)%?%{wk}%?%+Lw%? %{wk}"
+#  hardstatus alwayslastline "%{b1;0}$USER@%{b7;0}%H | %{b3;0}(load:%1` |%{b1;0} cpu: %2` | %{b2;0}net: %3`) %=%{b7;0}%D %Y-%m-%d %0c "
+#  caption always "%{1;7}%n%f %t %{7;0} | %-Lw%{4;7}%n%f %t%?(%u)%?%{7;0}%+Lw%="
 
 # detach on hangup
   autodetach            on              # default: on

--- a/etc/grml/screenrc_generic
+++ b/etc/grml/screenrc_generic
@@ -36,11 +36,6 @@
 
 # shell                 /bin/zsh
 
-# "sorendition": set the colors for
-# the "messages" and "text marking"
-# (ie text you mark in copy mode):
-  sorendition 10 99 # default!
-
 # use %n to display the window number and %t for its title:
   activity              "activity in %n (%t) [%w:%s]~"
 

--- a/etc/grml/screenrc_generic
+++ b/etc/grml/screenrc_generic
@@ -5,12 +5,12 @@
 # License:       This file is licensed under the GPL v2.
 ################################################################################
 
-  caption always "%{+b rk}$USER@%{wk}%H | %{yk}(load: %l)  %-21=%{wk}%D %Y-%m-%d %0c"
-  hardstatus alwayslastline "%{wr}%n%f %t %{kw} | %?%-Lw%?%{wb}%n*%f %t%?(%u)%?%{kw}%?%+Lw%? %{wk}"
+  caption always "%{b1;0}$USER@%{b7;0}%H | %=%{b7;0}%D %Y-%m-%d %0c "
+  hardstatus alwayslastline "%{1;7}%n%f %t %{7;0} | %-Lw%{4;7}%n%f %t%?(%u)%?%{7;0}%+Lw%="
 
 # switch order of caption and hardstatus:
-#  hardstatus alwayslastline "%{+b rk}$USER@%{wk}%H | %{yk}(load: %l |%{rk} cpu: %1` | %{Gk}net: %2`)  %-21=%{wk}%D %Y-%m-%d %0c"
-#  caption always "%{wr}%n%f %t %{kw} | %?%-Lw%?%{wb}%n*%f %t%?(%u)%?%{kw}%?%+Lw%? %{wk}"
+#  hardstatus alwayslastline "%{b1;0}$USER@%{b7;0}%H | %=%{b7;0}%D %Y-%m-%d %0c "
+#  caption always "%{1;7}%n%f %t %{7;0} | %-Lw%{4;7}%n%f %t%?(%u)%?%{7;0}%+Lw%="
 
 # detach on hangup
   autodetach            on              # default: on

--- a/etc/grml/screenrc_generic
+++ b/etc/grml/screenrc_generic
@@ -19,7 +19,6 @@
 # defsilence            off             # default: off
 # hardcopy_append       on              # default: off
   hardcopy_append       off             # default: off
-  nethack               on              # default: off
 # don't display the copyright page
   startup_message       off             # default: on
 # no annoying audible bell, please

--- a/etc/grml/screenrc_generic_v4
+++ b/etc/grml/screenrc_generic_v4
@@ -1,0 +1,143 @@
+# Filename:      /etc/grml/screenrc_generic
+# Purpose:       generic configuration file for GNU screen 4.x
+# Authors:       grml-team (grml.org), (c) Michael Prokop <mika@grml.org>
+# Bug-Reports:   see http://grml.org/bugs/
+# License:       This file is licensed under the GPL v2.
+################################################################################
+
+  caption always "%{+b rk}$USER@%{wk}%H | %{yk}(load: %l)  %-21=%{wk}%D %Y-%m-%d %0c"
+  hardstatus alwayslastline "%{wr}%n%f %t %{kw} | %?%-Lw%?%{wb}%n*%f %t%?(%u)%?%{kw}%?%+Lw%? %{wk}"
+
+# switch order of caption and hardstatus:
+#  hardstatus alwayslastline "%{+b rk}$USER@%{wk}%H | %{yk}(load: %l |%{rk} cpu: %1` | %{Gk}net: %2`)  %-21=%{wk}%D %Y-%m-%d %0c"
+#  caption always "%{wr}%n%f %t %{kw} | %?%-Lw%?%{wb}%n*%f %t%?(%u)%?%{kw}%?%+Lw%? %{wk}"
+
+# detach on hangup
+  autodetach            on              # default: on
+  crlf                  off             # default: off
+  deflogin              off             # default: on
+# defsilence            off             # default: off
+# hardcopy_append       on              # default: off
+  hardcopy_append       off             # default: off
+# don't display the copyright page
+  startup_message       off             # default: on
+# no annoying audible bell, please
+  vbell                 on
+
+  defscrollback         10000           # default: 100
+# msgminwait            3               # default: 1
+  silencewait           15              # default: 30
+
+  hardcopydir           $HOME/.hardcopy
+
+# fix the "screen.linux" terminal problem (see Debian BTS #238355 + #239776)
+#  term linux
+
+# shell                 /bin/zsh
+
+# use %n to display the window number and %t for its title:
+  activity              "activity in %n (%t) [%w:%s]~"
+
+# pass on the "beep" (CTRL-G) by adding a '~':
+  bell                  "bell     in %n (%t) [%w:%s]~"
+
+# pow_detach_msg:       Message shown when session
+#                       gets power detached.
+  pow_detach_msg "Screen session of \$LOGNAME \$:cr:\$:nl:ended."
+
+# vbell_msg:            Message shown when the
+#                       "virtual bell" rings.
+  vbell_msg             " *beep* "
+
+# Key bindings
+# Remove some default key bindings by binding
+# them to "nothing" (empty right-hand-side):
+# bind .  dumptermcap # default
+  bind .
+  bind ^\
+  bind \\
+
+# 040126 To be able to select windows with n > 9 ->
+# press "C-a - #" instead of just "C-a #"
+  bind - command -c select_1n
+  bind -c select_1n 0 select 10
+  bind -c select_1n 1 select 11
+  bind -c select_1n 2 select 12
+  bind -c select_1n 3 select 13
+  bind -c select_1n 4 select 14
+  bind -c select_1n 5 select 15
+  bind -c select_1n 6 select 16
+  bind -c select_1n 7 select 17
+  bind -c select_1n 8 select 18
+  bind -c select_1n 9 select 19
+  bind -c select_1n - command -c select_2n
+  bind -c select_2n 0 select 20
+  bind -c select_2n 1 select 21
+  bind -c select_2n 2 select 22
+  bind -c select_2n 3 select 23
+  bind -c select_2n 4 select 24
+  bind -c select_2n 5 select 25
+  bind -c select_2n 6 select 26
+  bind -c select_2n 7 select 27
+  bind -c select_2n 8 select 28
+  bind -c select_2n 9 select 29
+  bind -c select_2n - select -
+
+# Use the function keys F11 and F12 to cycle backwards/forwards in
+# the list of existing windows:
+#  bindkey -k F1 prev
+#  bindkey -k F2 next
+
+# remove some stupid / dangerous key bindings
+  bind k
+  bind ^k
+  bind .
+  bind ^\
+  bind \\
+  bind ^h
+  bind h  hardcopy
+# make them better
+  bind 'K' kill
+  bind 'I' login on
+  bind 'O' login off
+  bind '}' history
+
+# Paste - use 'P' instead of ']':
+# bind P # unbound by default
+  bind P paste .
+
+# Yet another hack:
+# Prepend/append register [/] to the paste if ^a^] is pressed.
+# This lets me have autoindent mode in vi.
+#  register [ "\033:se noai\015a"
+#  register ] "\033:se ai\015a"
+#  bind ^] paste [.]
+
+#      X - a fast way to lock the current screen.
+  bind X lockscreen
+
+# 030511 Workaround for stupid machines without xmodmap ;-)
+  bindkey -t °a stuff "ä"
+  bindkey -t °A stuff "Ä"
+  bindkey -t °o stuff "ö"
+  bindkey -t °O stuff "Ö"
+  bindkey -t °u stuff "ü"
+  bindkey -t °U stuff "Ü"
+  bindkey -t °s stuff "ß"
+
+  msgwait 1
+  version
+# change back to showing messages
+# for duration of two seconds:
+  msgwait 2
+
+# To get screen to add lines to xterm's scrollback buffer, uncomment the
+# following termcapinfo line which tells xterm to use the normal screen buffer
+# (which has scrollback), not the alternate screen buffer.
+  termcapinfo xterm|xterm-256color|xterms|xs|rxvt ti@:te@
+
+# Welcome the user:
+  echo "welcome BoFH!"
+
+# vim: ft=screen
+## END OF FILE #################################################################

--- a/etc/grml/screenrc_v4
+++ b/etc/grml/screenrc_v4
@@ -1,0 +1,142 @@
+# Filename:      /etc/grml/screenrc
+# Purpose:       main configuration file for GNU screen 4.x
+# Authors:       grml-team (grml.org), (c) Michael Prokop <mika@grml.org>
+# Bug-Reports:   see http://grml.org/bugs/
+# License:       This file is licensed under the GPL v2.
+################################################################################
+
+  backtick 1 0 60   /usr/bin/cpu-screen
+  backtick 2 0 60   /usr/bin/ip-screen
+  caption always "%{+b rk}$USER@%{wk}%H | %{yk}(load: %l |%{rk} cpu: %1` | %{Gk}net: %2`)  %-21=%{wk}%D %Y-%m-%d %0c"
+  hardstatus alwayslastline "%{wr}%n%f %t %{kw} | %?%-Lw%?%{wb}%n*%f %t%?(%u)%?%{kw}%?%+Lw%? %{wk}"
+
+# switch order of caption and hardstatus:
+#  hardstatus alwayslastline "%{+b kr}$USER@%{kw}%H | %{ky}(load: %l |%{kr} cpu: %1` | %{kG}net: %2`)  %-21=%{kw}%D %Y-%m-%d %0c"
+#  caption always "%{rw}%n%f %t %{wk} | %?%-Lw%?%{bw}%n*%f %t%?(%u)%?%{wk}%?%+Lw%? %{wk}"
+
+# detach on hangup
+  autodetach            on              # default: on
+  crlf                  off             # default: off
+  deflogin              off             # default: on
+# defsilence            off             # default: off
+# hardcopy_append       on              # default: off
+  hardcopy_append       off             # default: off
+# don't display the copyright page
+  startup_message       off             # default: on
+# no annoying audible bell, please
+  vbell                 on
+
+  defscrollback         10000           # default: 100
+# msgminwait            3               # default: 1
+  silencewait           15              # default: 30
+
+  hardcopydir           $HOME/.hardcopy
+
+# fix the "screen.linux" terminal problem (see Debian BTS #238355 + #239776)
+#  term linux
+
+# shell                 /bin/zsh
+
+# use %n to display the window number and %t for its title:
+  activity              "activity in %n (%t) [%w:%s]~"
+
+# pass on the "beep" (CTRL-G) by adding a '~':
+  bell                  "bell     in %n (%t) [%w:%s]~"
+
+# pow_detach_msg:       Message shown when session
+#                       gets power detached.
+  pow_detach_msg "Screen session of \$LOGNAME \$:cr:\$:nl:ended."
+
+# vbell_msg:            Message shown when the
+#                       "virtual bell" rings.
+  vbell_msg             " *beep* "
+
+# Key bindings
+# Remove some default key bindings by binding
+# them to "nothing" (empty right-hand-side):
+# bind .  dumptermcap # default
+  bind .
+# bind ^\
+# bind \\
+  bind .
+  bind k
+  bind ^k
+  bind ^h
+
+# 040126 To be able to select windows with n > 9 ->
+# press "C-a - #" instead of just "C-a #"
+  bind - command -c select_1n
+  bind -c select_1n 0 select 10
+  bind -c select_1n 1 select 11
+  bind -c select_1n 2 select 12
+  bind -c select_1n 3 select 13
+  bind -c select_1n 4 select 14
+  bind -c select_1n 5 select 15
+  bind -c select_1n 6 select 16
+  bind -c select_1n 7 select 17
+  bind -c select_1n 8 select 18
+  bind -c select_1n 9 select 19
+  bind -c select_1n - command -c select_2n
+  bind -c select_2n 0 select 20
+  bind -c select_2n 1 select 21
+  bind -c select_2n 2 select 22
+  bind -c select_2n 3 select 23
+  bind -c select_2n 4 select 24
+  bind -c select_2n 5 select 25
+  bind -c select_2n 6 select 26
+  bind -c select_2n 7 select 27
+  bind -c select_2n 8 select 28
+  bind -c select_2n 9 select 29
+  bind -c select_2n - select -
+
+# Use the function keys F11 and F12 to cycle backwards/forwards in
+# the list of existing windows:
+#  bindkey -k F1 prev
+#  bindkey -k F2 next
+
+  bind h  hardcopy
+# make them better
+  bind 'K' kill
+  bind 'I' login on
+  bind 'O' login off
+  bind '}' history
+
+# Paste - use 'P' instead of ']':
+# bind P # unbound by default
+  bind P paste .
+
+# Yet another hack:
+# Prepend/append register [/] to the paste if ^a^] is pressed.
+# This lets me have autoindent mode in vi.
+#  register [ "\033:se noai\015a"
+#  register ] "\033:se ai\015a"
+#  bind ^] paste [.]
+
+#      X - a fast way to lock the current screen.
+  bind X lockscreen
+
+# 030511 Workaround for stupid machines without xmodmap ;-)
+  bindkey -t °a stuff "ä"
+  bindkey -t °A stuff "Ä"
+  bindkey -t °o stuff "ö"
+  bindkey -t °O stuff "Ö"
+  bindkey -t °u stuff "ü"
+  bindkey -t °U stuff "Ü"
+  bindkey -t °s stuff "ß"
+
+  msgwait 1
+  version
+# change back to showing messages
+# for duration of two seconds:
+  msgwait 2
+
+# To get screen to add lines to xterm's scrollback buffer, uncomment the
+# following termcapinfo line which tells xterm to use the normal screen buffer
+# (which has scrollback), not the alternate screen buffer.
+  termcapinfo xterm|xterms|xs|rxvt ti@:te@
+
+# Welcome the user:
+  echo "welcome BoFH!"
+
+# vim: ft=screen
+## END OF FILE #################################################################

--- a/manpages/grml-scripts-core.1
+++ b/manpages/grml-scripts-core.1
@@ -18,6 +18,9 @@ output current / available cpu frequencies
 .SS ip-screen
 print ip address (IPv4 only) of configured network interfaces to stdout
 (useful for integration into GNU screen)
+.SS loadavg-screen
+print load average (from uptime)
+(useful for integration into GNU screen 5.x)
 
 .SH "BUGS"
 Probably. Please report any bugs you find and report

--- a/usr_bin/loadavg-screen
+++ b/usr_bin/loadavg-screen
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Filename:      loadavg-screen
+# Purpose:       output load average (replacement for GNU screen 4.x %l escape)
+# Authors:       grml-team (grml.org), (c) Chris Hofstaedtler <ch@grml.org>
+# Bug-Reports:   see http://grml.org/bugs/
+# License:       This file is licensed under the GPL v2.
+#******************************************************************************
+
+uptime | cut -f 4- -d':' -


### PR DESCRIPTION
Add loadavg-screen backtick program, as %l is gone. The colors/formatting of the caption/hardstatus lines are almost the same, barring brightness on green. Some things like +b seem to no longer work as documented, so put b into each color string. % no longer seems to need the -21 (and actually break when thats present).

Additionally, screen v5 seems to put "*" into the %f flags of the currently selected window, so we don't have to do it ourselves anymore. OTOH we get a useless "*" in the flags of the leftmost current window display too.

Maybe we don't need screenrc_v4 at all?
