### PR TITLE
zshrc: dirstack: fix chpwd math expression for unset DIRSTACKSIZE

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -1540,8 +1540,7 @@ if zstyle -T ':grml:chpwd:dirstack' enable; then
 
     function chpwd () {
         (( ZSH_SUBSHELL )) && return
-        [[ -z $DIRSTACKSIZE ]] && return
-        (( $DIRSTACKSIZE <= 0 )) && return
+        (( DIRSTACKSIZE <= 0 )) && return
         [[ -z $DIRSTACKFILE ]] && return
         grml_dirstack_filter $PWD && return
         GRML_PERSISTENT_DIRSTACK=(


### PR DESCRIPTION
Fixes #253.

`(( $DIRSTACKSIZE <= 0 ))` in the `chpwd` hook does literal text substitution before the arithmetic parser runs. When `DIRSTACKSIZE` is unset or empty, the expression becomes `(( <= 0 ))` and zsh errors with:

```
chpwd:2: bad math expression: operand expected at `<= 0 '
```

Also removes the `[[ -z $DIRSTACKSIZE ]] && return` line added in https://github.com/grml/grml-etc-core/pull/223: it looks like that was an AI-made attempt at fixing the same bug, but it's a workaround rather than a proper fix--the $ in the (( )) conditional shouldn't be there.