### PR TITLE
zshrc: check for /etc/os-release instead of /etc/debian_version

### DIFF
--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2540,7 +2540,7 @@ Enjoy your grml system with the zsh!$reset_color"
 }
 
 # debian stuff
-if [[ -r /etc/debian_version ]] ; then
+if grep -q -e '^ID=debian$' -e '^ID_LIKE=.*debian' /etc/os-release 2>/dev/null ; then
     if [[ -z "$GRML_NO_APT_ALIASES" ]]; then
         #a3# Execute \kbd{apt-cache policy}
         alias acp='apt-cache policy'


### PR DESCRIPTION
Looks like `/etc/debian_version` might be disappearing from base-files, see https://lists.ubuntu.com/archives/ubuntu-devel/2026-July/043633.html

(Thanks @zeha for the pointer)