### PR TITLE
loadavg-screen: fix which fields are output

### DIFF
--- a/usr_bin/loadavg-screen
+++ b/usr_bin/loadavg-screen
@@ -6,4 +6,4 @@
 # License:       This file is licensed under the GPL v2.
 #******************************************************************************
 
-cut -d' ' -f1-3 /proc/loadavg
+LC_ALL=C uptime | sed 's/.*: //'

--- a/usr_bin/loadavg-screen
+++ b/usr_bin/loadavg-screen
@@ -6,4 +6,4 @@
 # License:       This file is licensed under the GPL v2.
 #******************************************************************************
 
-uptime | cut -f 4- -d':' -
+cut -d' ' -f1-3 /proc/loadavg


### PR DESCRIPTION
The previous version, `uptime | cut -f 4- -d:`, produced output like

`38,  1 user,  load average: 0.23, 0.35, 0.20`

where the "38" is the minute field from " 11:49:41 up 5 days,  4:38,  1 user,  load average: 0.23, 0.35, 0.20".

Since `screenrc` already causes `load:` to be included in the status line, there is also no need to include the `load average: ` output from `uptime`.

We only need the first three fields from /proc/loadavg and don't have to rely on the `uptime` program at all; this also saves us a fork(). (Which is why I'd in fact prefer to put `cut -d' ' -f1-3 /proc/loadavg` into screenrc instead of having screen call a shell script.)