### PR TITLE
zshrc: update alias screen

### DIFF
--- a/doc/grmlzshrc.adoc
+++ b/doc/grmlzshrc.adoc
@@ -1021,10 +1021,9 @@ Executes the commands on the versioned patch queue from current repository.
 rmdir current working directory
 
 *screen* (_screen -c file_)::
-If invoking user is root, starts screen session with /etc/grml/screenrc
-as config file. If invoked by a regular user and users .screenc does not exist,
-starts screen with /etc/grml/screenrc_grml config if it exists, else fallbacks
-to /etc/grml/screenrc.
+Unless $HOME/.screenrc exists start a screen session with /etc/grml/screenrc
+as config file. If we detect screen to be an older release start the session
+with /etc/grml/screenrc_v4 instead.
 
 *su* (_sudo su_)::
 If user is running a Grml live system, don't ask for any password, if she

--- a/etc/zsh/zshrc
+++ b/etc/zsh/zshrc
@@ -2421,17 +2421,13 @@ hash -d www=/var/www
 
 # some aliases
 if check_com -c screen ; then
-    if [[ $UID -eq 0 ]] ; then
-        if [[ -r /etc/grml/screenrc ]]; then
-            alias screen='screen -c /etc/grml/screenrc'
-        fi
-    elif [[ ! -r $HOME/.screenrc ]] ; then
-        if [[ -r /etc/grml/screenrc_grml ]]; then
-            alias screen='screen -c /etc/grml/screenrc_grml'
-        else
-            if [[ -r /etc/grml/screenrc ]]; then
-                alias screen='screen -c /etc/grml/screenrc'
-            fi
+    SCREENRC=screenrc
+    if [ "${${${$(screen -v)#*version* }%% *}%%.*}" = 4 ]; then
+        SCREENRC=screenrc_v4
+    fi
+    if [[ ! -r "$HOME"/.screenrc ]]; then
+        if [[ -r /etc/grml/"$SCREENRC" ]]; then
+            alias screen="screen -c /etc/grml/$SCREENRC"
         fi
     fi
 fi


### PR DESCRIPTION
* Remove obsolete references to screenrc_grml.
* Allow for a personal screenrc for root aswell.
* Use the v4 file if we need to.
